### PR TITLE
Add missing DescribeSObjectResult properties and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use the jar in a maven project add the following to your pom.xml
 <dependency>
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>62.0.0</version>
+  <version>62.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>62.0.0</version>
+  <version>62.0.1</version>
   <packaging>jar</packaging>
 
   <name>standard-types</name>

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeSObjectResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeSObjectResult.java
@@ -20,63 +20,79 @@ import com.nawforce.runforce.System.*;
 
 @SuppressWarnings("unused")
 public class DescribeSObjectResult {
-	public Boolean Accessible;
-	public List<ChildRelationship> ChildRelationships;
-	public Boolean Createable;
-	public Boolean Custom;
-	public Boolean CustomSetting;
-	public Boolean Deletable;
-	public Boolean DeprecatedAndHidden;
-	public Boolean FeedEnabled;
-	public SObjectTypeFields Fields;
-	public SObjectTypeFieldSets FieldSets;
-	public Boolean HasSubtypes;
-	public Boolean IsSubtype;
-	public String KeyPrefix;
-	public String Label;
-	public String LabelPlural;
-	public String LocalName;
-	public Boolean Mergeable;
-	public Boolean MruEnabled;
-	public String Name;
-	public Boolean Queryable;
-	public List<RecordTypeInfo> RecordTypeInfos;
-	public Map<String,RecordTypeInfo> RecordTypeInfosByDeveloperName;
-	public Map<Id,RecordTypeInfo> RecordTypeInfosById;
-	public Map<String,RecordTypeInfo> RecordTypeInfosByName;
-	public Boolean Searchable;
-	public SObjectType SObjectType;
-	public Boolean Undeletable;
-	public Boolean Updateable;
+  public Boolean Accessible;
+  public String AssociateEntityType;
+  public String AssociateParentEntity;
+  public List<ChildRelationship> ChildRelationships;
+  public Boolean Createable;
+  public Boolean Custom;
+  public Boolean CustomSetting;
+  public Boolean DataTranslationEnabled;
+  public Boolean DefaultImplementation;
+  public Boolean Deletable;
+  public Boolean DeprecatedAndHidden;
+  public Boolean FeedEnabled;
+  public SObjectTypeFields Fields;
+  public SObjectTypeFieldSets FieldSets;
+  public Boolean HasSubtypes;
+  public String ImplementedBy;
+  public String ImplementsInterfaces;
+  public Boolean IsInterface;
+  public Boolean IsSubtype;
+  public String KeyPrefix;
+  public String Label;
+  public String LabelPlural;
+  public String LocalName;
+  public Boolean Mergeable;
+  public Boolean MruEnabled;
+  public String Name;
+  public Boolean Queryable;
+  public List<RecordTypeInfo> RecordTypeInfos;
+  public Map<String,RecordTypeInfo> RecordTypeInfosByDeveloperName;
+  public Map<Id,RecordTypeInfo> RecordTypeInfosById;
+  public Map<String,RecordTypeInfo> RecordTypeInfosByName;
+  public Boolean Searchable;
+  public SObjectDescribeOptions SObjectDescribeOption;
+  public SObjectType SObjectType;
+  public Boolean Undeletable;
+  public Boolean Updateable;
 
-    protected DescribeSObjectResult(){throw new java.lang.UnsupportedOperationException();}
+  protected DescribeSObjectResult() {throw new java.lang.UnsupportedOperationException();}
 
-	public List<ChildRelationship> getChildRelationships() {throw new java.lang.UnsupportedOperationException();}
-	public SObjectTypeFieldSets getFieldSets() {throw new java.lang.UnsupportedOperationException();}
-	public SObjectTypeFields getFields() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean getHasSubtypes() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean getIsSubtype() {throw new java.lang.UnsupportedOperationException();}
-	public String getKeyPrefix() {throw new java.lang.UnsupportedOperationException();}
-	public String getLabel() {throw new java.lang.UnsupportedOperationException();}
-	public String getLabelPlural() {throw new java.lang.UnsupportedOperationException();}
-	public String getLocalName() {throw new java.lang.UnsupportedOperationException();}
-	public String getName() {throw new java.lang.UnsupportedOperationException();}
-	public List<RecordTypeInfo> getRecordTypeInfos() {throw new java.lang.UnsupportedOperationException();}
-	public Map<String,RecordTypeInfo> getRecordTypeInfosByDeveloperName() {throw new java.lang.UnsupportedOperationException();}
-	public Map<Id,RecordTypeInfo> getRecordTypeInfosById() {throw new java.lang.UnsupportedOperationException();}
-	public Map<String,RecordTypeInfo> getRecordTypeInfosByName() {throw new java.lang.UnsupportedOperationException();}
-	public SObjectType getSObjectType() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isAccessible() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isCreateable() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isCustom() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isCustomSetting() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isDeletable() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isDeprecatedAndHidden() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isFeedEnabled() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isMergeable() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isMruEnabled() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isQueryable() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isSearchable() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isUndeletable() {throw new java.lang.UnsupportedOperationException();}
-	public Boolean isUpdateable() {throw new java.lang.UnsupportedOperationException();}
+  public String getAssociateEntityType() {throw new java.lang.UnsupportedOperationException();}
+  public String getAssociateParentEntity() {throw new java.lang.UnsupportedOperationException();}
+  public List<ChildRelationship> getChildRelationships() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean getDataTranslationEnabled() {throw new java.lang.UnsupportedOperationException();}
+  public String getDefaultImplementation() {throw new java.lang.UnsupportedOperationException();}
+  public SObjectTypeFields getFields() {throw new java.lang.UnsupportedOperationException();}
+  public SObjectTypeFieldSets getFieldSets() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean getHasSubtypes() {throw new java.lang.UnsupportedOperationException();}
+  public String getImplementedBy() {throw new java.lang.UnsupportedOperationException();}
+  public String getImplementsInterfaces() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean getIsInterface() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean getIsSubtype() {throw new java.lang.UnsupportedOperationException();}
+  public String getKeyPrefix() {throw new java.lang.UnsupportedOperationException();}
+  public String getLabel() {throw new java.lang.UnsupportedOperationException();}
+  public String getLabelPlural() {throw new java.lang.UnsupportedOperationException();}
+  public String getLocalName() {throw new java.lang.UnsupportedOperationException();}
+  public String getName() {throw new java.lang.UnsupportedOperationException();}
+  public List<RecordTypeInfo> getRecordTypeInfos() {throw new java.lang.UnsupportedOperationException();}
+  public Map<String,RecordTypeInfo> getRecordTypeInfosByDeveloperName() {throw new java.lang.UnsupportedOperationException();}
+  public Map<Id,RecordTypeInfo> getRecordTypeInfosById() {throw new java.lang.UnsupportedOperationException();}
+  public Map<String,RecordTypeInfo> getRecordTypeInfosByName() {throw new java.lang.UnsupportedOperationException();}
+  public SObjectDescribeOptions getSObjectDescribeOption() {throw new java.lang.UnsupportedOperationException();}
+  public SObjectType getSObjectType() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isAccessible() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isCreateable() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isCustom() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isCustomSetting() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isDeletable() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isDeprecatedAndHidden() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isFeedEnabled() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isMergeable() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isMruEnabled() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isQueryable() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isSearchable() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isUndeletable() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isUpdateable() {throw new java.lang.UnsupportedOperationException();}
 }


### PR DESCRIPTION
Formatter has obscured the changes, but fields/methods for:

```
AssociateEntityType
AssociateParentEntity
DataTranslationEnabled
DefaultImplementation
ImplementedBy
ImplementsInterfaces
IsInterface
SObjectDescribeOption
```