### PR TITLE
fix: change getSObjects() return type from List to RecordSet$ for for…

### DIFF
--- a/src/main/java/com/nawforce/runforce/System/SObject.java
+++ b/src/main/java/com/nawforce/runforce/System/SObject.java
@@ -16,6 +16,7 @@ package com.nawforce.runforce.System;
 
 import com.nawforce.runforce.Database.DMLOptions;
 import com.nawforce.runforce.Database.Error;
+import com.nawforce.runforce.Internal.RecordSet$;
 import com.nawforce.runforce.SObjectStubs.UserRecordAccess;
 import com.nawforce.runforce.Schema.SObjectField;
 import com.nawforce.runforce.Schema.SObjectType;
@@ -50,8 +51,8 @@ public class SObject {
 	public SObject getSObject(SObjectField field) {throw new java.lang.UnsupportedOperationException();}
 	public SObject getSObject(String field) {throw new java.lang.UnsupportedOperationException();}
 	public SObjectType getSObjectType() {throw new java.lang.UnsupportedOperationException();}
-	public List<SObject> getSObjects(SObjectField field) {throw new java.lang.UnsupportedOperationException();}
-	public List<SObject> getSObjects(String field) {throw new java.lang.UnsupportedOperationException();}
+	public RecordSet$<SObject> getSObjects(SObjectField field) {throw new java.lang.UnsupportedOperationException();}
+	public RecordSet$<SObject> getSObjects(String field) {throw new java.lang.UnsupportedOperationException();}
 	public SObject getValues(String id) {throw new java.lang.UnsupportedOperationException();}
 	public Boolean hasErrors() {throw new java.lang.UnsupportedOperationException();}
 	public Boolean isClone() {throw new java.lang.UnsupportedOperationException();}


### PR DESCRIPTION
…-loop compatibility

Change getSObjects() methods to return RecordSet$<SObject> instead of List<SObject> to support recordset iteration in for-loops like SOQL queries and Database.query().

This enables the syntax:
for(List<SObject> cursorBlock : parent.getSObjects('relationshipName')) {}

Without this fix, the above produces the error:
"Incompatible types in assignment, from 'System.SObject' to 'System.List<System.SObject>'"

Changes:
- Add import for com.nawforce.runforce.Internal.RecordSet$
- Change getSObjects(SObjectField) return type: List<SObject> → RecordSet$<SObject>
- Change getSObjects(String) return type: List<SObject> → RecordSet$<SObject>

Fixes #38
Related: apex-dev-tools/apex-ls#328