### PR TITLE
Support API 65

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,7 @@ This repository provides Java stub declarations for Salesforce platform types to
 Every method follows this exact pattern:
 
 ```java
+// [link to class documentation page]
 @SuppressWarnings("unused")
 public class ExampleClass {
   public ReturnType methodName(ParamType param) {throw new java.lang.UnsupportedOperationException();}
@@ -96,6 +97,13 @@ mvn install -Dgpg.skip=true  # Skip GPG signing for local builds
 - `options/field-service.txt` - Lists Field Service related types
 
 ## Common Tasks
+
+### Accessing Salesforce Documentation
+
+When working with Apex class reference pages, use **Playwright MCP** to access the content since the Salesforce documentation pages cannot be fetched directly. Use the browser tools to navigate to and extract information from:
+
+- `https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/` - Main Apex Reference documentation
+- Specific class documentation pages for method signatures, constructors, and property definitions
 
 ### Adding New Salesforce Types
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,157 @@
+# AI Coding Agent Instructions for Standard-Types
+
+## Project Overview
+
+This repository provides Java stub declarations for Salesforce platform types to support static analysis in apex-ls. All classes are compilation-compatible but throw `UnsupportedOperationException` at runtime since they're analysis stubs, not implementations.
+
+## Architecture & Package Structure
+
+### Core Namespace Pattern
+
+- **Root package**: `com.nawforce.runforce`
+- **Namespace mapping**: Each Salesforce namespace becomes a Java package (e.g., `System` → `com.nawforce.runforce.System`)
+- **Cross-references**: Types reference each other using proper `com.nawforce.runforce.*` imports, never native Java types (except `Object`)
+
+### Key Package Categories
+
+- **`System/`** - Core Apex types (String, Integer, List, Map, Database operations)
+- **`Schema/`** - Metadata and reflection types (SObjectType, DescribeSObjectResult)
+- **`ConnectApi/`** - REST API representations and service classes
+- **`Database/`** - DML operation results and batch processing interfaces
+- **`SObjectStubs/`** - Standard object stubs (User, AuthProvider, etc.)
+- **`aiplatform/`** - AI platform service types (newer additions)
+
+## Development Patterns
+
+### Stub Implementation Pattern
+
+Every method follows this exact pattern:
+
+```java
+@SuppressWarnings("unused")
+public class ExampleClass {
+    public ReturnType methodName(ParamType param) {
+        throw new java.lang.UnsupportedOperationException();
+    }
+}
+```
+
+### Type Import Rules ⚠️
+
+- **ALWAYS use** `com.nawforce.runforce.System.String` (not `java.lang.String`)
+- **ALWAYS use** `com.nawforce.runforce.System.Integer` (not `java.lang.Integer`)
+- **ALWAYS use** `com.nawforce.runforce.System.List` (not `java.util.List`)
+- **ONLY exception**: `Object` can reference native Java type
+
+### Class Structure Pattern
+
+```java
+package com.nawforce.runforce.PackageName;
+
+import com.nawforce.runforce.System.String;  // Correct import
+
+@SuppressWarnings("unused")
+public class ClassName {
+    public String field;  // Public fields for data classes
+
+    protected ClassName() {throw new java.lang.UnsupportedOperationException();}  // Constructor
+
+    public String getField() {throw new java.lang.UnsupportedOperationException();}  // Methods
+}
+```
+
+## Build & Development
+
+### Maven Build
+
+```bash
+mvn install -Dgpg.skip=true  # Skip GPG signing for local builds
+```
+
+### Version Strategy
+
+- Versions track Salesforce API releases (e.g., v64.X.X = Summer '25 API)
+- Built for Java 1.8 compatibility for wider tooling support
+
+### File Organization
+
+- No tests (stubs are compilation-only)
+- `options/field-service.txt` - Lists Field Service related types
+- IntelliJ templates available for rapid stub creation using live template `stub`
+
+## Common Tasks
+
+### Adding New Salesforce Types
+
+1. Determine correct package based on Salesforce namespace
+2. Use IntelliJ `stub` live template or copy existing similar class
+3. Ensure all imports use `com.nawforce.runforce.*` types
+4. Add `@SuppressWarnings("unused")` annotation
+5. Verify compilation with `mvn compile`
+
+### Cross-Package Dependencies
+
+When types reference each other across packages, always use full package imports:
+
+```java
+// In ConnectApi package referencing System types
+import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.List;
+```
+
+### Static Analysis Integration
+
+These stubs are consumed by apex-ls via JVM reflection - the structure and method signatures must exactly match Salesforce platform APIs for static analysis accuracy.
+
+## Salesforce API Version Updates
+
+### Update Process Overview
+
+This repository is the **first step** in a multi-stage process for updating Apex LS with new Salesforce API versions:
+
+1. **Standard-types update** (this repo) - Add new platform types from Salesforce release notes
+2. **SObject-types update** - Generate org-specific types using describe calls
+3. **Apex-ls integration** - Update dependencies and validate with comprehensive tests
+
+### Platform Types Update Workflow
+
+#### 1. Research New API Changes
+
+- Review [Salesforce Release Notes](https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm) sections:
+  - `Development > Apex` - Language feature changes
+  - `Development > New and Changed Items for Developers > Apex: New and Changed Items` - Updated namespaces and classes
+  - `Development > ConnectApi` - API service updates
+  - Beta features under `Development` (Analytics, AI/Einstein, Wave)
+
+#### 2. Cross-reference with Apex Reference
+
+- Use [Apex Reference Guide](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_ref_guide.htm) to get exact method signatures
+- Look up new classes and namespaces identified in release notes
+- Verify parameter types and return types match exactly
+- **Expect PDF context**: Apex Reference Guide PDF should be provided to cross-reference method signatures, parameter types, and relationships between classes within a single context window
+
+#### 3. Implementation Steps
+
+1. Create new classes following established patterns in appropriate `com.nawforce.runforce.*` packages
+2. Update existing classes with new methods/fields
+3. Ensure all new imports use `com.nawforce.runforce.*` types
+4. Build and verify: `mvn compile`
+5. Reference previous API update PRs for examples (e.g., [API 61 changes](https://github.com/apex-dev-tools/standard-types/pull/26/files))
+
+#### 4. Integration Testing
+
+After publishing updated standard-types, apex-ls tests will validate:
+
+- **Type count validation** - Update count in `PlatformTypesValidationTest`
+- **`All outer types are valid`** - Catches missing `com.nawforce.runforce.*` imports
+- **`Exceptions are valid`** - Ensures Exception classes properly extend `System.Exception`
+
+Common failures: `Reference to non-platform type java.lang...` errors indicate missing Apex type imports.
+
+## Sources
+
+- [apex-ls repository](https://github.com/apex-dev-tools/apex-ls) - The Apex Language Server that consumes these stubs
+- [API Updates Documentation](https://github.com/apex-dev-tools/apex-ls/blob/main/doc/API_Updates.md) - Detailed update process workflow
+- [sobject-types repository](https://github.com/apex-dev-tools/sobject-types) - Companion repository for SObject type stubs
+- [Salesforce Release Notes](https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm) - Official API change documentation
+- [Apex Reference Guide](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_ref_guide.htm) - Method signatures and type definitions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,15 @@ public class ExampleClass {
 - **ALWAYS use** `com.nawforce.runforce.System.List` (not `java.util.List`)
 - **ONLY exception**: `Object` can reference native Java type
 
+### Method Name Collision Rules ⚠️
+
+- **Methods that clash with `java.lang.Object`** must be suffixed with `$`:
+  - `equals(Object obj)` → `equals$(Object obj)`
+  - `hashCode()` → `hashCode$()`
+  - `toString()` → `toString$()`
+- This prevents compilation conflicts with inherited Object methods
+- Apply this rule when Salesforce documentation shows these method names
+
 ### Class Structure Patterns
 
 #### Static Method Classes
@@ -74,7 +83,8 @@ public class InstanceClass {
 ### Documentation Adherence Rules
 
 - **Method/property order**: Maintain alphabetical order as documented in Salesforce API docs
-- **Getters/setters**: Only create methods explicitly documented; do not auto-generate
+- **⚠️ CRITICAL: Getters/setters**: NEVER auto-generate getter/setter methods. ONLY create methods that are explicitly documented in the Salesforce API documentation. Properties are public fields unless documentation shows otherwise.
+- **⚠️ CRITICAL: Methods only**: Create ONLY the methods that appear in the official Salesforce documentation. Do not add any convenience methods, utility methods, or standard Java patterns not documented.
 - **Constructor patterns**: Static method classes have no constructors; instance classes have public default constructor plus any documented constructors
 - **Copyright year**: Use current year (2025) for newly created files
 
@@ -100,10 +110,32 @@ mvn install -Dgpg.skip=true  # Skip GPG signing for local builds
 
 ### Accessing Salesforce Documentation
 
-When working with Apex class reference pages, use **Playwright MCP** to access the content since the Salesforce documentation pages cannot be fetched directly. Use the browser tools to navigate to and extract information from:
+When working with Apex reference pages, use **Playwright MCP** to access the content since the Salesforce documentation pages cannot be fetched directly. Use the browser tools to navigate to and extract information from:
 
 - `https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/` - Main Apex Reference documentation
 - Specific class documentation pages for method signatures, constructors, and property definitions
+
+### Implementing Namespaces
+
+Use **Playwright MCP** to access the namespace documentation page (e.g., `apex_namespace_[namespace].htm`) since Salesforce docs cannot be fetched directly. Extract all type names and their documentation links. Types can then be added systematically using the links and checked off.
+
+Create `.github/[namespace-name]-todo.md` with a simple structure:
+
+```markdown
+# [Namespace] TODO List
+
+## Classes
+
+- [ ] **TypeName** - [Documentation](link)
+
+## Interfaces
+
+- [ ] **TypeName** - [Documentation](link)
+
+## Enums
+
+- [ ] **TypeName** - [Documentation](link)
+```
 
 ### Adding New Salesforce Types
 
@@ -115,9 +147,10 @@ When working with Apex class reference pages, use **Playwright MCP** to access t
    - Instance classes: Public default constructor + documented constructors
 5. **Import only `com.nawforce.runforce.*` types** (except `Object`)
 6. **Add `@SuppressWarnings("unused")` annotation**
-7. **Create only documented methods** - no auto-generated getters/setters
+7. **⚠️ CRITICAL: Create only documented methods** - NEVER create getter/setter methods or any other methods not explicitly shown in the Salesforce documentation. Only public fields and documented methods.
 8. **Add documentation link** - include comment above class: `// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/[class-doc-page].htm`
-9. **Verify compilation** with `mvn compile`
+9. **Do not create types without documentation** - If you encounter a referenced type that doesn't exist, do not attempt to create it without access to its official Salesforce documentation page. Ask for the documentation link if necessary.
+10. **Verify compilation** with `mvn compile`
 
 ### Updating Existing Classes
 
@@ -125,7 +158,8 @@ When working with Apex class reference pages, use **Playwright MCP** to access t
 2. **Follow alphabetical insertion** for new methods per API documentation
 3. **Preserve existing constructor patterns** (static vs instance class style)
 4. **Add documentation link** if not already present - include comment above class with Salesforce documentation URL
-5. **Validate with compilation** after changes
+5. **⚠️ CRITICAL: Do not create types without documentation** - If you encounter a referenced type that doesn't exist, do not attempt to create it without access to its official Salesforce documentation page. Ask for the documentation link if necessary.
+6. **Validate with compilation** after changes
 
 ### Cross-Package Dependencies
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,9 +30,7 @@ Every method follows this exact pattern:
 ```java
 @SuppressWarnings("unused")
 public class ExampleClass {
-    public ReturnType methodName(ParamType param) {
-        throw new java.lang.UnsupportedOperationException();
-    }
+  public ReturnType methodName(ParamType param) {throw new java.lang.UnsupportedOperationException();}
 }
 ```
 
@@ -43,22 +41,41 @@ public class ExampleClass {
 - **ALWAYS use** `com.nawforce.runforce.System.List` (not `java.util.List`)
 - **ONLY exception**: `Object` can reference native Java type
 
-### Class Structure Pattern
+### Class Structure Patterns
+
+#### Static Method Classes
+
+Classes with only static methods (no instance state):
 
 ```java
-package com.nawforce.runforce.PackageName;
-
-import com.nawforce.runforce.System.String;  // Correct import
-
 @SuppressWarnings("unused")
-public class ClassName {
-    public String field;  // Public fields for data classes
-
-    protected ClassName() {throw new java.lang.UnsupportedOperationException();}  // Constructor
-
-    public String getField() {throw new java.lang.UnsupportedOperationException();}  // Methods
+public class StaticMethodClass {
+  public static ReturnType methodName(ParamType param) {throw new java.lang.UnsupportedOperationException();}
 }
 ```
+
+#### Instance Classes
+
+Classes with non-static methods/properties require public constructors:
+
+```java
+@SuppressWarnings("unused")
+public class InstanceClass {
+  public String field;  // Public fields as documented
+
+  public InstanceClass() {throw new java.lang.UnsupportedOperationException();}  // Default constructor
+  public InstanceClass(String param) {throw new java.lang.UnsupportedOperationException();}  // Documented constructors
+
+  public String getField() {throw new java.lang.UnsupportedOperationException();}  // Only documented methods
+}
+```
+
+### Documentation Adherence Rules
+
+- **Method/property order**: Maintain alphabetical order as documented in Salesforce API docs
+- **Getters/setters**: Only create methods explicitly documented; do not auto-generate
+- **Constructor patterns**: Static method classes have no constructors; instance classes have public default constructor plus any documented constructors
+- **Copyright year**: Use current year (2025) for newly created files
 
 ## Build & Development
 
@@ -77,17 +94,30 @@ mvn install -Dgpg.skip=true  # Skip GPG signing for local builds
 
 - No tests (stubs are compilation-only)
 - `options/field-service.txt` - Lists Field Service related types
-- IntelliJ templates available for rapid stub creation using live template `stub`
 
 ## Common Tasks
 
 ### Adding New Salesforce Types
 
-1. Determine correct package based on Salesforce namespace
-2. Use IntelliJ `stub` live template or copy existing similar class
-3. Ensure all imports use `com.nawforce.runforce.*` types
-4. Add `@SuppressWarnings("unused")` annotation
-5. Verify compilation with `mvn compile`
+1. **Determine package location** based on Salesforce namespace mapping
+2. **Set copyright year** to current year (2025) for new files
+3. **Preserve documentation order** - maintain alphabetical method/property order from API docs
+4. **Choose class pattern**:
+   - Static method classes: No constructors
+   - Instance classes: Public default constructor + documented constructors
+5. **Import only `com.nawforce.runforce.*` types** (except `Object`)
+6. **Add `@SuppressWarnings("unused")` annotation**
+7. **Create only documented methods** - no auto-generated getters/setters
+8. **Add documentation link** - include comment above class: `// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/[class-doc-page].htm`
+9. **Verify compilation** with `mvn compile`
+
+### Updating Existing Classes
+
+1. **Maintain existing method order** when adding new methods
+2. **Follow alphabetical insertion** for new methods per API documentation
+3. **Preserve existing constructor patterns** (static vs instance class style)
+4. **Add documentation link** if not already present - include comment above class with Salesforce documentation URL
+5. **Validate with compilation** after changes
 
 ### Cross-Package Dependencies
 
@@ -102,51 +132,6 @@ import com.nawforce.runforce.System.List;
 ### Static Analysis Integration
 
 These stubs are consumed by apex-ls via JVM reflection - the structure and method signatures must exactly match Salesforce platform APIs for static analysis accuracy.
-
-## Salesforce API Version Updates
-
-### Update Process Overview
-
-This repository is the **first step** in a multi-stage process for updating Apex LS with new Salesforce API versions:
-
-1. **Standard-types update** (this repo) - Add new platform types from Salesforce release notes
-2. **SObject-types update** - Generate org-specific types using describe calls
-3. **Apex-ls integration** - Update dependencies and validate with comprehensive tests
-
-### Platform Types Update Workflow
-
-#### 1. Research New API Changes
-
-- Review [Salesforce Release Notes](https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm) sections:
-  - `Development > Apex` - Language feature changes
-  - `Development > New and Changed Items for Developers > Apex: New and Changed Items` - Updated namespaces and classes
-  - `Development > ConnectApi` - API service updates
-  - Beta features under `Development` (Analytics, AI/Einstein, Wave)
-
-#### 2. Cross-reference with Apex Reference
-
-- Use [Apex Reference Guide](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_ref_guide.htm) to get exact method signatures
-- Look up new classes and namespaces identified in release notes
-- Verify parameter types and return types match exactly
-- **Expect PDF context**: Apex Reference Guide PDF should be provided to cross-reference method signatures, parameter types, and relationships between classes within a single context window
-
-#### 3. Implementation Steps
-
-1. Create new classes following established patterns in appropriate `com.nawforce.runforce.*` packages
-2. Update existing classes with new methods/fields
-3. Ensure all new imports use `com.nawforce.runforce.*` types
-4. Build and verify: `mvn compile`
-5. Reference previous API update PRs for examples (e.g., [API 61 changes](https://github.com/apex-dev-tools/standard-types/pull/26/files))
-
-#### 4. Integration Testing
-
-After publishing updated standard-types, apex-ls tests will validate:
-
-- **Type count validation** - Update count in `PlatformTypesValidationTest`
-- **`All outer types are valid`** - Catches missing `com.nawforce.runforce.*` imports
-- **`Exceptions are valid`** - Ensures Exception classes properly extend `System.Exception`
-
-Common failures: `Reference to non-platform type java.lang...` errors indicate missing Apex type imports.
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Stub declarations for Salesforce platform types encoded as compilable Java.
 
 These stub declarations help support static analysis of Apex code in [apex-ls](https://github.com/apex-dev-tools/apex-ls) but you may also find them useful for other purposes. They have been encoded in Java to get the benefit of type checking by javac so it easier to spot when something is amiss. In apex-ls JVM reflection is used to 'read' the stubs as part of the static analysis.
 
-The library is versioned to reflect Salesforce API numbers, so currently v64.X.X matches the Salesforce Summer '25 API.
+The library is versioned to reflect Salesforce API numbers, so currently v65.X.X matches the Salesforce Winter '26 API.
 
 ## Installation
 
@@ -14,7 +14,7 @@ To use the jar in a maven project add the following to your pom.xml
 <dependency>
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>64.0.0</version>
+  <version>65.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>64.0.0</version>
+  <version>65.0.0</version>
   <packaging>jar</packaging>
 
   <name>standard-types</name>

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AbstractResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AbstractResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Datetime;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AbstractResponse.htm
+@SuppressWarnings("unused")
+public abstract class AbstractResponse implements GatewayResponse {
+  public AbstractResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AbstractTransactionResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AbstractTransactionResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Double;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AbstractTransactionResponse.htm
+@SuppressWarnings("unused")
+public abstract class AbstractTransactionResponse extends AbstractResponse {
+  public AbstractTransactionResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AccountHolderType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AccountHolderType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_AccountHolderType.htm
+@SuppressWarnings("unused")
+public enum AccountHolderType {
+  Business,
+  Individual
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AccountType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AccountType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_AccountType.htm
+@SuppressWarnings("unused")
+public enum AccountType {
+  Checking,
+  Savings
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AddressRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AddressRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AddressRequest.htm
+@SuppressWarnings("unused")
+public class AddressRequest {
+  public String city;
+  public String companyName;
+  public String country;
+  public String postalCode;
+  public String state;
+  public String street;
+
+  public AddressRequest() {throw new java.lang.UnsupportedOperationException();}
+  public AddressRequest(String street, String city, String state, String country, String postalCode) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AlternativePaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AlternativePaymentMethodRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AlternativePaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public class AlternativePaymentMethodRequest {
+  public String accountId;
+  public String email;
+  public String gatewayToken;
+  public String gatewayTokenDetails;
+  public String name;
+
+  public AlternativePaymentMethodRequest(String gatewayToken) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AlternativePaymentMethodResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AlternativePaymentMethodResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Id;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AlternativePaymentMethodResponse.htm
+@SuppressWarnings("unused")
+public class AlternativePaymentMethodResponse {
+
+  public AlternativePaymentMethodResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAccountId(Id accountId) {throw new java.lang.UnsupportedOperationException();}
+  public void setComments(String comments) {throw new java.lang.UnsupportedOperationException();}
+  public void setEmail(String email) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayToken(String gatewayToken) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayTokenDetails(String gatewayTokenDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setName(String name) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuditParamsRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuditParamsRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuditParamsRequest.htm
+@SuppressWarnings("unused")
+public abstract class AuditParamsRequest {
+  public String email;
+  public String ipAddress;
+  public String macAddress;
+  public String phone;
+
+  public AuditParamsRequest(String email, String macAddress, String ipAddress, String phone) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthApiPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthApiPaymentMethodRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Salesforce, Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuthApiPaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public class AuthApiPaymentMethodRequest extends BaseApiPaymentMethodRequest {
+  public CardPaymentMethodRequest cardPaymentMethod;
+
+  public AuthApiPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+  public AuthApiPaymentMethodRequest(CardPaymentMethodRequest cardPaymentMethodRequest) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuthorizationRequest.htm
+@SuppressWarnings("unused")
+public class AuthorizationRequest extends BaseRequest {
+  public String accountId;
+  public Double amount;
+  public String comments;
+  public String currencyIsoCode;
+  public AuthApiPaymentMethodRequest paymentMethod;
+
+  public AuthorizationRequest() {throw new java.lang.UnsupportedOperationException();}
+  public AuthorizationRequest(Double amount) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuthorizationResponse.htm
+@SuppressWarnings("unused")
+public class AuthorizationResponse extends AbstractTransactionResponse implements GatewayResponse {
+  public AuthorizationResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setAuthorizationExpirationDate(Datetime authExpDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAuthCode(String gatewayAuthCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setPaymentMethodTokenizationResponse(PaymentMethodTokenizationResponse paymentMethodTokenizationResponse) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationReversalRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationReversalRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuthorizationReversalRequest.htm
+@SuppressWarnings("unused")
+public class AuthorizationReversalRequest extends BaseRequest {
+  public String accountId;
+  public Double amount;
+  public String paymentAuthorizationId;
+
+  public AuthorizationReversalRequest() {throw new java.lang.UnsupportedOperationException();}
+  public AuthorizationReversalRequest(Double amount, String authorizationId) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationReversalResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationReversalResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuthorizationReversalResponse.htm
+@SuppressWarnings("unused")
+public class AuthorizationReversalResponse extends AbstractTransactionResponse implements GatewayResponse {
+  public AuthorizationReversalResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BankPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BankPaymentMethodRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_BankPaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public class BankPaymentMethodRequest {
+  public String accountHolderFirstName;
+  public String accountHolderLastName;
+  public String accountHolderName;
+  public AccountHolderType accountHolderType;
+  public String accountId;
+  public String accountNumber;
+  public AccountType accountType;
+  public Boolean autoPay;
+  public String bankCode;
+  public BankType bankType;
+  public String comments;
+  public String email;
+  public String mandate;
+  public String nickName;
+  public StandardEntryClassCode standardEntryClassCode;
+
+  public BankPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BankPaymentMethodResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BankPaymentMethodResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_BankPaymentMethodResponse.htm
+@SuppressWarnings("unused")
+public class BankPaymentMethodResponse {
+
+  public BankPaymentMethodResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAccountHolderType(AccountHolderType accountHolderType) {throw new java.lang.UnsupportedOperationException();}
+  public void setAccountId(String accountId) {throw new java.lang.UnsupportedOperationException();}
+  public void setAccountType(AccountType accountType) {throw new java.lang.UnsupportedOperationException();}
+  public void setBankCode(String bankCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setBankName(String bankName) {throw new java.lang.UnsupportedOperationException();}
+  public void setBankType(BankType bankType) {throw new java.lang.UnsupportedOperationException();}
+  public void setComments(String comments) {throw new java.lang.UnsupportedOperationException();}
+  public void setEmail(String email) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayToken(String gatewayToken) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayTokenDetails(String gatewayTokenDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setLast4(String lastFour) {throw new java.lang.UnsupportedOperationException();}
+  public void setName(String name) {throw new java.lang.UnsupportedOperationException();}
+  public void setSavedPaymentMethodId(String savedPaymentMethodId) {throw new java.lang.UnsupportedOperationException();}
+  public void setStandardEntryClassCode(StandardEntryClassCode standardEntryClassCode) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BankType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BankType.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_BankType.htm
+@SuppressWarnings("unused")
+public enum BankType {
+  Ach,
+  Bacs,
+  Becs,
+  SepaDebit
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BaseApiPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BaseApiPaymentMethodRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_BaseApiPaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public abstract class BaseApiPaymentMethodRequest {
+  public AddressRequest address;
+  public String id;
+  public Boolean saveForFuture;
+
+  public BaseApiPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+  public BaseApiPaymentMethodRequest(AddressRequest address, String id, Boolean saveForFuture) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BaseNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BaseNotification.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_BaseNotification.htm
+@SuppressWarnings("unused")
+public abstract class BaseNotification {
+
+  public BaseNotification() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setId(String id) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+  public void setStatus(NotificationStatus status) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BasePaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BasePaymentMethodRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_BasePaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public abstract class BasePaymentMethodRequest {
+
+  public BasePaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BaseRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BaseRequest.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Map;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_BaseRequest.htm
+@SuppressWarnings("unused")
+public class BaseRequest {
+  public BaseRequest() {throw new java.lang.UnsupportedOperationException();}
+  public BaseRequest(String additionalData, Map<String, String> idempotencyKey) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CaptureNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CaptureNotification.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CaptureNotification.htm
+@SuppressWarnings("unused")
+public class CaptureNotification extends BaseNotification {
+
+  public CaptureNotification() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CaptureRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CaptureRequest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CaptureRequest.htm
+@SuppressWarnings("unused")
+public class CaptureRequest extends BaseRequest {
+  public String accountId;
+  public Double amount;
+  public String paymentAuthorizationId;
+
+  public CaptureRequest() {throw new java.lang.UnsupportedOperationException();}
+  public CaptureRequest(Double amount, String authorizationId) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CaptureResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CaptureResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CaptureResponse.htm
+@SuppressWarnings("unused")
+public class CaptureResponse extends AbstractTransactionResponse implements GatewayResponse {
+  public CaptureResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CardCategory.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CardCategory.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_CardCategory.htm
+@SuppressWarnings("unused")
+public enum CardCategory {
+  CreditCard,
+  DebitCard
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CardPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CardPaymentMethodRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Salesforce, Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CardPaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public class CardPaymentMethodRequest extends BasePaymentMethodRequest {
+  public String accountId;
+  public Boolean autoPay;
+  public CardCategory cardCategory;
+  public String cardHolderFirstName;
+  public String cardHolderLastName;
+  public String cardHolderName;
+  public String cardNumber;
+  public CardType cardType;
+  public String cvv;
+  public String email;
+  public Integer expiryMonth;
+  public Integer expiryYear;
+  public String inputCardType;
+  public Integer startMonth;
+  public Integer startYear;
+
+  public CardPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+  public CardPaymentMethodRequest(CardCategory cardCategory) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CardPaymentMethodResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CardPaymentMethodResponse.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CardPaymentMethodResponse.htm
+@SuppressWarnings("unused")
+public class CardPaymentMethodResponse {
+
+  public CardPaymentMethodResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAccountId(Object accountId) {throw new java.lang.UnsupportedOperationException();}
+  public void setAutoPay(Boolean autoPay) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardBin(String cardBin) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardCategory(CardCategory cardCategory) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardHolderFirstName(String cardHolderFirstName) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardHolderLastName(String cardHolderLastName) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardHolderName(String cardHolderName) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardLastFour(String cardLastFour) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardType(String cardType) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardTypeCategory(CardType cardTypeCategory) {throw new java.lang.UnsupportedOperationException();}
+  public void setComments(String comments) {throw new java.lang.UnsupportedOperationException();}
+  public void setDisplayCardNumber(String displayCardNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setEmail(String email) {throw new java.lang.UnsupportedOperationException();}
+  public void setExpiryMonth(Integer expiryMonth) {throw new java.lang.UnsupportedOperationException();}
+  public void setExpiryYear(Integer expiryYear) {throw new java.lang.UnsupportedOperationException();}
+  public void setNickName(String nickName) {throw new java.lang.UnsupportedOperationException();}
+  public void setStartMonth(Integer startMonth) {throw new java.lang.UnsupportedOperationException();}
+  public void setStartYear(Integer startYear) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CardType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CardType.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_CardType.htm
+@SuppressWarnings("unused")
+public enum CardType {
+  AmericanExpress,
+  DinersClub,
+  Jcb,
+  Maestro,
+  MasterCard,
+  Visa
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CustomMetadataTypeInfo.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CustomMetadataTypeInfo.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CustomMetadataTypeInfo.htm
+@SuppressWarnings("unused")
+public class CustomMetadataTypeInfo {
+  public CustomMetadataTypeInfo(String cmtRecordId, String cmtSfResultCodeFieldName) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/GatewayErrorResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/GatewayErrorResponse.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_GatewayErrorResponse.htm
+@SuppressWarnings("unused")
+public class GatewayErrorResponse implements GatewayResponse {
+
+  public GatewayErrorResponse(String errorCode, String errorMessage) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/GatewayNotificationResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/GatewayNotificationResponse.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Blob;
+import com.nawforce.runforce.System.Integer;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_GatewayNotificationResponse.htm
+@SuppressWarnings("unused")
+public class GatewayNotificationResponse extends AbstractResponse implements GatewayResponse {
+  public GatewayNotificationResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setResponseBody(Blob responseBody) {throw new java.lang.UnsupportedOperationException();}
+  public void setStatusCode(Integer statusCode) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/GatewayResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/GatewayResponse.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_interface_commercepayments_GatewayResponse.htm
+@SuppressWarnings("unused")
+public interface GatewayResponse {
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/NotificationClient.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/NotificationClient.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_NotificationClient.htm
+@SuppressWarnings("unused")
+public class NotificationClient {
+
+  public NotificationClient() {throw new java.lang.UnsupportedOperationException();}
+
+  public static NotificationSaveResult record(BaseNotification notification) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/NotificationSaveResult.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/NotificationSaveResult.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_NotificationSaveResult.htm
+@SuppressWarnings("unused")
+public class NotificationSaveResult {
+
+  public NotificationSaveResult() {throw new java.lang.UnsupportedOperationException();}
+
+  public String getErrorMessage() {throw new java.lang.UnsupportedOperationException();}
+  public Integer getStatusCode() {throw new java.lang.UnsupportedOperationException();}
+  public Boolean isSuccess() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/NotificationStatus.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/NotificationStatus.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_NotificationStatus.htm
+@SuppressWarnings("unused")
+public enum NotificationStatus {
+  Failed,
+  Success
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayAdapter.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayAdapter.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_interface_commercepayments_PaymentGatewayAdapter.htm
+@SuppressWarnings("unused")
+public interface PaymentGatewayAdapter {
+  GatewayResponse processRequest(PaymentGatewayContext context);
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayAsyncAdapter.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayAsyncAdapter.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_interface_commercepayments_PaymentGatewayAsyncAdapter.htm
+@SuppressWarnings("unused")
+public interface PaymentGatewayAsyncAdapter {
+  GatewayNotificationResponse processNotification(PaymentGatewayNotificationContext gatewayNotificationContext);
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayContext.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayContext.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentGatewayContext.htm
+@SuppressWarnings("unused")
+public class PaymentGatewayContext {
+  public PaymentGatewayContext(Object request, String requestType) {throw new java.lang.UnsupportedOperationException();}
+
+  public Object getPaymentRequest() {throw new java.lang.UnsupportedOperationException();}
+  public String getPaymentRequestType() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayNotificationContext.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayNotificationContext.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentGatewayNotificationContext.htm
+@SuppressWarnings("unused")
+public class PaymentGatewayNotificationContext {
+  public PaymentGatewayNotificationRequest gatewayNotificationRequest;
+
+  public PaymentGatewayNotificationContext() {throw new java.lang.UnsupportedOperationException();}
+
+  public PaymentGatewayNotificationRequest getPaymentGatewayNotificationRequest() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayNotificationRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentGatewayNotificationRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Blob;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentGatewayNotificationRequest.htm
+@SuppressWarnings("unused")
+public class PaymentGatewayNotificationRequest {
+  public Blob requestBody;
+
+  public PaymentGatewayNotificationRequest() {throw new java.lang.UnsupportedOperationException();}
+
+  public Map<String,String> getHeaders() {throw new java.lang.UnsupportedOperationException();}
+  public Blob getRequestBody() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodDetailsResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodDetailsResponse.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentMethodDetailsResponse.htm
+@SuppressWarnings("unused")
+public class PaymentMethodDetailsResponse {
+  public PaymentMethodDetailsResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAlternativePaymentMethod(AlternativePaymentMethodResponse alternativePaymentMethod) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardPaymentMethod(CardPaymentMethodResponse cardPaymentMethod) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodTokenizationRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodTokenizationRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentMethodTokenizationRequest.htm
+@SuppressWarnings("unused")
+public class PaymentMethodTokenizationRequest {
+  public AddressRequest address;
+  public BankPaymentMethodRequest bankPaymentMethod;
+  public CardPaymentMethodRequest cardPaymentMethod;
+
+  public PaymentMethodTokenizationRequest() {throw new java.lang.UnsupportedOperationException();}
+  public PaymentMethodTokenizationRequest(String paymentGatewayId) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodTokenizationResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodTokenizationResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentMethodTokenizationResponse.htm
+@SuppressWarnings("unused")
+public class PaymentMethodTokenizationResponse {
+  public PaymentMethodTokenizationResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
+  public void setBankName(String bankName) {throw new java.lang.UnsupportedOperationException();}
+  public void setChecksum(String checksum) {throw new java.lang.UnsupportedOperationException();}
+  public void setCustomerReference(String customerReference) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayToken(String gatewayToken) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayTokenDetails(String gatewayTokenDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayTokenEncrypted(String gatewayTokenEncrypted) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentsHttp.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentsHttp.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.HttpRequest;
+import com.nawforce.runforce.System.HttpResponse;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PaymentsHttp.htm
+@SuppressWarnings("unused")
+public class PaymentsHttp {
+  public PaymentsHttp() {throw new java.lang.UnsupportedOperationException();}
+
+  public HttpResponse send(HttpRequest request) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthApiPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthApiPaymentMethodRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PostAuthApiPaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public class PostAuthApiPaymentMethodRequest extends BaseApiPaymentMethodRequest {
+  public AlternativePaymentMethodRequest alternativePaymentMethod;
+  public CardPaymentMethodRequest cardPaymentMethod;
+
+  public PostAuthApiPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+  public PostAuthApiPaymentMethodRequest(AlternativePaymentMethodRequest alternativePaymentMethodRequest) {throw new java.lang.UnsupportedOperationException();}
+  public PostAuthApiPaymentMethodRequest(CardPaymentMethodRequest cardPaymentMethodRequest) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthorizationRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthorizationRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PostAuthorizationRequest.htm
+@SuppressWarnings("unused")
+public class PostAuthorizationRequest extends BaseRequest {
+  public String accountId;
+  public Double amount;
+  public String comments;
+  public String currencyIsoCode;
+  public String paymentMethod;
+
+  public PostAuthorizationRequest() {throw new java.lang.UnsupportedOperationException();}
+  public PostAuthorizationRequest(Double amount) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthorizationResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthorizationResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PostAuthorizationResponse.htm
+@SuppressWarnings("unused")
+public class PostAuthorizationResponse extends AbstractTransactionResponse {
+
+  public PostAuthorizationResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAlternativePaymentMethodResponse(AlternativePaymentMethodResponse alternativePaymentMethod) {throw new java.lang.UnsupportedOperationException();}
+  public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
+  public void setAuthorizationExpirationDate(Datetime authExpDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setCardPaymentMethodResponse(CardPaymentMethodResponse cardPaymentMethod) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAuthCode(String gatewayAuthCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setPaymentMethodDetailsResponse(PaymentMethodDetailsResponse paymentMethodDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setPaymentMethodTokenizationResponse(PaymentMethodTokenizationResponse paymentMethodTokenizationResponse) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundNotification.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_ReferencedRefundNotification.htm
+@SuppressWarnings("unused")
+public class ReferencedRefundNotification extends BaseNotification {
+
+  public ReferencedRefundNotification() {throw new java.lang.UnsupportedOperationException();}
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setId(String id) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+  public void setStatus(NotificationStatus status) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_ReferencedRefundRequest.htm
+@SuppressWarnings("unused")
+public class ReferencedRefundRequest extends RefundRequest {
+  public String PaymentId;
+  public String accountId;
+  public Double amount;
+
+  public ReferencedRefundRequest(Double amount, String paymentId) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_ReferencedRefundResponse.htm
+@SuppressWarnings("unused")
+public class ReferencedRefundResponse extends AbstractTransactionResponse implements GatewayResponse {
+  public ReferencedRefundResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/RefundRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/RefundRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_RefundRequest.htm
+@SuppressWarnings("unused")
+public class RefundRequest extends BaseRequest {
+
+  public RefundRequest() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/RequestType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/RequestType.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_RequestType.htm
+@SuppressWarnings("unused")
+public enum RequestType {
+  Authorize,
+  AuthorizationReversal,
+  Capture,
+  PostAuth,
+  ReferencedRefund,
+  Sale,
+  Tokenize
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleApiPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleApiPaymentMethodRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_SaleApiPaymentMethodRequest.htm
+@SuppressWarnings("unused")
+public class SaleApiPaymentMethodRequest extends BaseApiPaymentMethodRequest {
+  public CardPaymentMethodRequest cardPaymentMethod;
+  public StandardEntryClassCode standardEntryClassCode;
+
+  public SaleApiPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}
+  public SaleApiPaymentMethodRequest(CardPaymentMethodRequest cardPaymentMethodRequest) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleNotification.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_SaleNotification.htm
+@SuppressWarnings("unused")
+public class SaleNotification extends BaseNotification {
+  public SaleNotification() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_SaleRequest.htm
+@SuppressWarnings("unused")
+public class SaleRequest extends BaseRequest {
+  public String accountId;
+  public Double amount;
+  public String comments;
+  public String currencyIsoCode;
+  public SaleApiPaymentMethodRequest paymentMethod;
+  public Map<String,String> paymentMethodData;
+
+  public SaleRequest() {throw new java.lang.UnsupportedOperationException();}
+  public SaleRequest(Double amount) {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_SaleResponse.htm
+@SuppressWarnings("unused")
+public class SaleResponse extends AbstractTransactionResponse implements GatewayResponse {
+  public SaleResponse() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setPaymentMethodTokenizationResponse(PaymentMethodTokenizationResponse paymentMethodTokenizationResponse) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SalesforceResultCode.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SalesforceResultCode.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_SalesforceResultCode.htm
+@SuppressWarnings("unused")
+public enum SalesforceResultCode {
+  Decline,
+  Indeterminate,
+  PermanentFail,
+  RequiresReview,
+  Success,
+  SystemError,
+  ValidationError
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SalesforceResultCodeInfo.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SalesforceResultCodeInfo.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_SalesforceResultCodeInfo.htm
+@SuppressWarnings("unused")
+public class SalesforceResultCodeInfo {
+  public SalesforceResultCodeInfo() {throw new java.lang.UnsupportedOperationException();}
+  public SalesforceResultCodeInfo(CustomMetadataTypeInfo customMetadataTypeInfo) {throw new java.lang.UnsupportedOperationException();}
+  public SalesforceResultCodeInfo(SalesforceResultCode salesforceResultCode) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/StandardEntryClassCode.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/StandardEntryClassCode.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_StandardEntryClassCode.htm
+@SuppressWarnings("unused")
+public enum StandardEntryClassCode {
+  Ccd,
+  Ppd,
+  Tel,
+  Web
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/TokenizeNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/TokenizeNotification.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_TokenizeNotification.htm
+@SuppressWarnings("unused")
+public class TokenizeNotification extends BaseNotification {
+  public TokenizeNotification() {throw new java.lang.UnsupportedOperationException();}
+
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayToken(String gatewayToken) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayTokenEncrypted(String gatewayTokenEncrypted) {throw new java.lang.UnsupportedOperationException();}
+  public void setId(String id) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
+  public void setStatus(NotificationStatus status) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContent.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContent.java
@@ -9,11 +9,14 @@ import com.nawforce.runforce.System.Integer;
 import com.nawforce.runforce.System.List;
 import com.nawforce.runforce.System.String;
 
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_ConnectAPI_ManagedContent_static_methods.htm
 @SuppressWarnings("unused")
 public class ManagedContent {
-  public static ManagedContentDocumentClone cloneManagedContentDocument(String contentKeyOrId, ManagedContentDocumentCloneInput ManagedContentCloneInputParam) {throw new UnsupportedOperationException();}
+  public static ManagedContentDocumentClone cloneManagedContentDocument(String contentKeyOrId, ManagedContentDocumentCloneInput ManagedContentCloneInputParam) {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentDocument createManagedContent(ManagedContentDocumentInput ManagedContentInputParam) {throw new java.lang.UnsupportedOperationException();}
+  public static ManagedContentProviderInstance createManagedContentProvider(ManagedContentProviderInstanceInput providerInstanceInput) {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentDocument createManagedContentWithMedia(ManagedContentDocumentInput ManagedContentInputParam, BinaryInput contentData) {throw new java.lang.UnsupportedOperationException();}
+  public static void deleteManagedContentProviderInstance(String providerInstanceId) {throw new java.lang.UnsupportedOperationException();}
   public static void deleteManagedContentVariant(String variantId) {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentVersionCollection getAllContent(String channelId, Integer pageParam, Integer pageSize, String language, String managedContentType, Boolean includeMetadata, String startDate, String endDate) {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentVersionCollection getAllContent(String channelId, Integer pageParam, Integer pageSize, String language, String managedContentType, Boolean includeMetadata, String startDate, String endDate, Boolean showAbsoluteUrl) {throw new java.lang.UnsupportedOperationException();}
@@ -31,6 +34,7 @@ public class ManagedContent {
   public static ManagedContentVersionCollection getManagedContentByTopicsAndContentKeys(String communityId, List<String> contentKeys, List<String> topics, Integer pageParam, Integer pageSize, String language, String managedContentType, Boolean showAbsoluteUrl) {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentVersionCollection getManagedContentByTopicsAndIds(String communityId, List<String> managedContentIds, List<String> topics, Integer pageParam, Integer pageSize, String language, String managedContentType) {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentVersionCollection getManagedContentByTopicsAndIds(String communityId, List<String> managedContentIds, List<String> topics, Integer pageParam, Integer pageSize, String language, String managedContentType, Boolean showAbsoluteUrl) {throw new java.lang.UnsupportedOperationException();}
+  public static ManagedContentProviderCollection getManagedContentProviders() {throw new java.lang.UnsupportedOperationException();}
   public static ManagedContentSpace getManagedContentSpace(String contentSpaceId) {throw new java.lang.UnsupportedOperationException();}
   public static MCSFolderShareCollection getMCSFolderShares(String folderId) {throw new java.lang.UnsupportedOperationException();}
   public static MCSFolderShareTargetCollection getMCSFolderShareTargets(String folderId) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProvider.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_connectapi_output_managed_content_provider.htm
+@SuppressWarnings("unused")
+public class ManagedContentProvider {
+  public String componentDefinition;
+  public String icon;
+  public String label;
+  public String providerId;
+  public List<ManagedContentProviderInstance> providerInstances;
+  public String providerLightningComponentId;
+  public ManagedContentProviderType type;
+
+  public ManagedContentProvider() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderCollection.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderCollection.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_connectapi_output_managed_content_provider_collection.htm
+@SuppressWarnings("unused")
+public class ManagedContentProviderCollection {
+  public String currentPageUrl;
+  public String nextPageUrl;
+  public List<ManagedContentProvider> providers;
+  public Integer total;
+
+  public ManagedContentProviderCollection() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderInstance.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderInstance.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_connectapi_output_managed_content_provider_instance.htm
+@SuppressWarnings("unused")
+public class ManagedContentProviderInstance {
+  public String instanceKey;
+  public Boolean isDefault;
+  public String name;
+  public String providerInstanceId;
+
+  public ManagedContentProviderInstance() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderInstanceInput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderInstanceInput.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_connectapi_input_managed_content_provider_instance.htm
+@SuppressWarnings("unused")
+public class ManagedContentProviderInstanceInput {
+  public String instanceKey;
+  public Boolean isDefault;
+  public String name;
+  public String providerLightningComponentId;
+
+  public ManagedContentProviderInstanceInput() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderType.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/ManagedContentProviderType.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/connectAPI_enums.htm#ManagedContentProviderTypeEnum
+@SuppressWarnings("unused")
+public enum ManagedContentProviderType {
+  DigitalAssetManager
+}


### PR DESCRIPTION
Used copilot and playwright MCP to generate classes by reading the documentation for classes mentioned in the release notes (including a previously unimplemented namespace, CommercePayments).

Copilot workflow was a bit like this:

- Create a todo list of type names and doc page urls
- Load up each page with playwright
- Add the type, prioritise any others that are referenced by that type next
- Check them off the todo list

Was a bit slower than hoped, but faster than writing out each class by hand.

Encountered issues:
- Have to repeat in small runs, otherwise it attempts to "optimise" and make up multiple class definitions without using the doc. Similar issues with the class format being lost mid run.
- Class relationships, i.e extends/implements are often missed and needed extra prompting. Some inherited methods are duplicated because the doc references them twice.
- Also tried using PDF version but it was too big / copilot could not read it well, even after using text extract tool
- Web pages cannot be fetched normally due to lazy load/cookie consent on SF help - hence Playwright

Otherwise this release didn't have any "core" Apex type changes.