### PR TITLE
Add `String.template(Map<String, Object>)` stub

### DIFF
--- a/src/main/java/com/nawforce/runforce/System/String.java
+++ b/src/main/java/com/nawforce/runforce/System/String.java
@@ -119,6 +119,7 @@ public class String {
 	public String substringBetween(String open, String close) {throw new java.lang.UnsupportedOperationException();}
 	public String substringBetween(String tag) {throw new java.lang.UnsupportedOperationException();}
 	public String swapCase() {throw new java.lang.UnsupportedOperationException();}
+	public String template(Map<String, Object> values) {throw new java.lang.UnsupportedOperationException();}
 	public String toLowerCase() {throw new java.lang.UnsupportedOperationException();}
 	public String toLowerCase(String locale) {throw new java.lang.UnsupportedOperationException();}
 	public String toUpperCase() {throw new java.lang.UnsupportedOperationException();}


### PR DESCRIPTION
## Summary
- Add the Summer ’26 `String.template(Map<String, Object>)` instance stub to the Apex `String` type.
- Keep the implementation consistent with the existing unsupported-operation placeholders in `String.java`.

## Testing
- `mvn compile -Dgpg.skip=true` passed locally.