### PR TITLE
Add API 66 and 67 System type signatures

### DIFF
--- a/src/main/java/com/nawforce/runforce/System/IntegrationTest.java
+++ b/src/main/java/com/nawforce/runforce/System/IntegrationTest.java
@@ -1,0 +1,20 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.System;
+
+@SuppressWarnings("unused")
+public class IntegrationTest {
+  public static void commitTestOnly() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/System/Limits.java
+++ b/src/main/java/com/nawforce/runforce/System/Limits.java
@@ -18,8 +18,14 @@ package com.nawforce.runforce.System;
 public class Limits {
   public static Integer getAggregateQueries() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getLimitAggregateQueries() {throw new java.lang.UnsupportedOperationException();}
+  public static Integer getApexCursors() {throw new java.lang.UnsupportedOperationException();}
+  public static Integer getLimitApexCursors() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getApexCursorRows() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getLimitApexCursorRows() {throw new java.lang.UnsupportedOperationException();}
+  public static Integer getApexPaginationCursors() {throw new java.lang.UnsupportedOperationException();}
+  public static Integer getLimitApexPaginationCursors() {throw new java.lang.UnsupportedOperationException();}
+  public static Integer getApexPaginationCursorRows() {throw new java.lang.UnsupportedOperationException();}
+  public static Integer getLimitApexPaginationCursorRows() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getFetchCallsOnApexCursor() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getLimitFetchCallsOnApexCursor() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getAsyncCalls() {throw new java.lang.UnsupportedOperationException();}
@@ -83,4 +89,3 @@ public class Limits {
   public static Integer getScriptStatements() {throw new java.lang.UnsupportedOperationException();}
   public static Integer getLimitScriptStatements() {throw new java.lang.UnsupportedOperationException();}
 }
-

--- a/src/main/java/com/nawforce/runforce/System/System.java
+++ b/src/main/java/com/nawforce/runforce/System/System.java
@@ -44,6 +44,7 @@ public class System {
 	public static void pauseJobByName(String jobName) {throw new java.lang.UnsupportedOperationException();}
 	public static List<Id> process(List<Id> workitemIds, String action, String comments, String nextApprover) {throw new java.lang.UnsupportedOperationException();}
 	public static Integer purgeOldAsyncJobs(Date date) {throw new java.lang.UnsupportedOperationException();}
+	public static Integer purgeOldAsyncJobs(Date date, Integer numOfJobs) {throw new java.lang.UnsupportedOperationException();}
 	public static Version requestVersion() {throw new java.lang.UnsupportedOperationException();}
 	public static ResetPasswordResult resetPassword(Id userId, Boolean sendUserEmail) {throw new java.lang.UnsupportedOperationException();}
 	public static ResetPasswordResult resetPasswordWithEmailTemplate(Id userId, Boolean sendUserEmail, String emailTemplateName) {throw new java.lang.UnsupportedOperationException();}


### PR DESCRIPTION
## Summary
- Add new API 66 `Limits` counters for Apex cursors and pagination cursors
- Add the `System.purgeOldAsyncJobs(Date, Integer)` overload
- Add `System.IntegrationTest` with `commitTestOnly()` for API 67

## Testing
- `mvn -q -DskipTests compile` passed