### PR TITLE
Update CommercePayments type definitions for API 66.0 and 67.0

### DIFF
--- a/src/main/java/com/nawforce/runforce/CommercePayments/AbstractResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AbstractResponse.java
@@ -17,5 +17,7 @@ public abstract class AbstractResponse implements GatewayResponse {
   public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setRetryCategory(RetryCategory retryCategory) {throw new java.lang.UnsupportedOperationException();}
+  public void setRetryDecision(RetryDecision retryDecision) {throw new java.lang.UnsupportedOperationException();}
   public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationRequest.java
@@ -5,6 +5,7 @@
 package com.nawforce.runforce.CommercePayments;
 
 import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Map;
 import com.nawforce.runforce.System.String;
 import com.nawforce.runforce.System.Boolean;
 import com.nawforce.runforce.System.Integer;
@@ -17,6 +18,7 @@ public class AuthorizationRequest extends BaseRequest {
   public String comments;
   public String currencyIsoCode;
   public AuthApiPaymentMethodRequest paymentMethod;
+  public Map<String,String> paymentMethodData;
 
   public AuthorizationRequest() {throw new java.lang.UnsupportedOperationException();}
   public AuthorizationRequest(Double amount) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/AuthorizationResponse.java
@@ -7,6 +7,7 @@ package com.nawforce.runforce.CommercePayments;
 import com.nawforce.runforce.System.Datetime;
 import com.nawforce.runforce.System.Double;
 import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Boolean;
 
 // https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_AuthorizationResponse.htm
 @SuppressWarnings("unused")
@@ -14,6 +15,7 @@ public class AuthorizationResponse extends AbstractTransactionResponse implement
   public AuthorizationResponse() {throw new java.lang.UnsupportedOperationException();}
 
   public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
   public void setAuthorizationExpirationDate(Datetime authExpDate) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayAuthCode(String gatewayAuthCode) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BaseApiPaymentMethodRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BaseApiPaymentMethodRequest.java
@@ -13,6 +13,7 @@ import com.nawforce.runforce.System.String;
 public abstract class BaseApiPaymentMethodRequest {
   public AddressRequest address;
   public String id;
+  public PaymentMethodIdType idType;
   public Boolean saveForFuture;
 
   public BaseApiPaymentMethodRequest() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/BaseNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/BaseNotification.java
@@ -15,6 +15,7 @@ public abstract class BaseNotification {
   public BaseNotification() {throw new java.lang.UnsupportedOperationException();}
 
   public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/CaptureNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/CaptureNotification.java
@@ -4,9 +4,12 @@
 
 package com.nawforce.runforce.CommercePayments;
 
+import com.nawforce.runforce.System.String;
+
 // https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_CaptureNotification.htm
 @SuppressWarnings("unused")
 public class CaptureNotification extends BaseNotification {
 
   public CaptureNotification() {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/CommercePayments/EnhancedPaymentDataInput.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/EnhancedPaymentDataInput.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_EnhancedPaymentDataInput.htm
+@SuppressWarnings("unused")
+public class EnhancedPaymentDataInput {
+  public Map<String,String> additionalAttributes;
+  public Double discountAmount;
+  public Double dutyAmount;
+  public String invoiceNumber;
+  public List<LineItemInput> lineItems;
+  public String referenceId;
+  public Double salesTaxAmount;
+  public String shipFromZip;
+  public String shipToCountry;
+  public String shipToZip;
+  public Double shippingAmount;
+  public Double taxRate;
+  public Double totalTaxAmount;
+
+  public EnhancedPaymentDataInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/LineItemInput.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/LineItemInput.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_LineItemInput.htm
+@SuppressWarnings("unused")
+public class LineItemInput {
+  public Map<String,String> additionalAttributes;
+  public String commodityCode;
+  public String description;
+  public Double discount;
+  public Boolean discountIndicator;
+  public Double dutyAmount;
+  public String grossNetIndicator;
+  public String lineItemId;
+  public Double lineItemTotal;
+  public String name;
+  public Integer quantity;
+  public Double shippingAmount;
+  public String sku;
+  public Double taxAmount;
+  public Double taxRate;
+  public Double unitPrice;
+  public String uom;
+
+  public LineItemInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodIdType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodIdType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_PaymentMethodIdType.htm
+@SuppressWarnings("unused")
+public enum PaymentMethodIdType {
+  CardPaymentMethod,
+  SavedPaymentMethod
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodTokenizationRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodTokenizationRequest.java
@@ -14,6 +14,7 @@ public class PaymentMethodTokenizationRequest {
   public AddressRequest address;
   public BankPaymentMethodRequest bankPaymentMethod;
   public CardPaymentMethodRequest cardPaymentMethod;
+  public Boolean savedByMerchant;
 
   public PaymentMethodTokenizationRequest() {throw new java.lang.UnsupportedOperationException();}
   public PaymentMethodTokenizationRequest(String paymentGatewayId) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthorizationResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PostAuthorizationResponse.java
@@ -6,6 +6,7 @@ package com.nawforce.runforce.CommercePayments;
 
 import com.nawforce.runforce.System.Boolean;
 import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
 import com.nawforce.runforce.System.String;
 
 // https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_PostAuthorizationResponse.htm
@@ -15,10 +16,18 @@ public class PostAuthorizationResponse extends AbstractTransactionResponse {
   public PostAuthorizationResponse() {throw new java.lang.UnsupportedOperationException();}
 
   public void setAlternativePaymentMethodResponse(AlternativePaymentMethodResponse alternativePaymentMethod) {throw new java.lang.UnsupportedOperationException();}
+  public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
   public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
   public void setAuthorizationExpirationDate(Datetime authExpDate) {throw new java.lang.UnsupportedOperationException();}
-  public void setCardPaymentMethodResponse(CardPaymentMethodResponse cardPaymentMethod) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayAuthCode(String gatewayAuthCode) {throw new java.lang.UnsupportedOperationException();}
-  public void setPaymentMethodDetailsResponse(PaymentMethodDetailsResponse paymentMethodDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayReferenceNumber(String gatewayReferenceNumber) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
+  public void setPaymentMethodDetails(PaymentMethodDetailsResponse paymentMethodDetails) {throw new java.lang.UnsupportedOperationException();}
   public void setPaymentMethodTokenizationResponse(PaymentMethodTokenizationResponse paymentMethodTokenizationResponse) {throw new java.lang.UnsupportedOperationException();}
+  public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundNotification.java
@@ -14,6 +14,7 @@ public class ReferencedRefundNotification extends BaseNotification {
 
   public ReferencedRefundNotification() {throw new java.lang.UnsupportedOperationException();}
   public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayReferenceDetails(String gatewayReferenceDetails) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/ReferencedRefundResponse.java
@@ -7,6 +7,7 @@ package com.nawforce.runforce.CommercePayments;
 import com.nawforce.runforce.System.Datetime;
 import com.nawforce.runforce.System.Double;
 import com.nawforce.runforce.System.String;
+import com.nawforce.runforce.System.Boolean;
 
 // https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_commercepayments_ReferencedRefundResponse.htm
 @SuppressWarnings("unused")
@@ -14,6 +15,7 @@ public class ReferencedRefundResponse extends AbstractTransactionResponse implem
   public ReferencedRefundResponse() {throw new java.lang.UnsupportedOperationException();}
 
   public void setAmount(Double amount) {throw new java.lang.UnsupportedOperationException();}
+  public void setAsync(Boolean async) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayDate(Datetime gatewayDate) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayMessage(String gatewayMessage) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/RetryCategory.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/RetryCategory.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_RetryCategory.htm
+@SuppressWarnings("unused")
+public enum RetryCategory {
+  CardLimit,
+  GatewayConnection,
+  PaymentInformation,
+  PaymentProcessing,
+  Security,
+  Unknown
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/RetryDecision.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/RetryDecision.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.CommercePayments;
+
+// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_commercepayments_RetryDecision.htm
+@SuppressWarnings("unused")
+public enum RetryDecision {
+  NonRetriable,
+  Retriable
+}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleNotification.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleNotification.java
@@ -12,4 +12,6 @@ public class SaleNotification extends BaseNotification {
   public SaleNotification() {throw new java.lang.UnsupportedOperationException();}
 
   public void setGatewayAvsCode(String gatewayAvsCode) {throw new java.lang.UnsupportedOperationException();}
+  public void setRetryCategory(RetryCategory retryCategory) {throw new java.lang.UnsupportedOperationException();}
+  public void setRetryDecision(RetryDecision retryDecision) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleRequest.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleRequest.java
@@ -17,8 +17,11 @@ public class SaleRequest extends BaseRequest {
   public Double amount;
   public String comments;
   public String currencyIsoCode;
+  public EnhancedPaymentDataInput enhancedPaymentData;
+  public String paymentInitiationSourceId;
   public SaleApiPaymentMethodRequest paymentMethod;
   public Map<String,String> paymentMethodData;
+  public Boolean submittedByMerchant;
 
   public SaleRequest() {throw new java.lang.UnsupportedOperationException();}
   public SaleRequest(Double amount) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/CommercePayments/SaleResponse.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/SaleResponse.java
@@ -24,5 +24,7 @@ public class SaleResponse extends AbstractTransactionResponse implements Gateway
   public void setGatewayResultCode(String gatewayResultCode) {throw new java.lang.UnsupportedOperationException();}
   public void setGatewayResultCodeDescription(String gatewayResultCodeDescription) {throw new java.lang.UnsupportedOperationException();}
   public void setPaymentMethodTokenizationResponse(PaymentMethodTokenizationResponse paymentMethodTokenizationResponse) {throw new java.lang.UnsupportedOperationException();}
+  public void setRetryCategory(RetryCategory retryCategory) {throw new java.lang.UnsupportedOperationException();}
+  public void setRetryDecision(RetryDecision retryDecision) {throw new java.lang.UnsupportedOperationException();}
   public void setSalesforceResultCodeInfo(SalesforceResultCodeInfo salesforceResultCodeInfo) {throw new java.lang.UnsupportedOperationException();}
 }


### PR DESCRIPTION
## Summary
- Added the new CommercePayments enums introduced in API 66.0: `RetryCategory`, `RetryDecision`, and `PaymentMethodIdType`.
- Updated CommercePayments request/response stubs with the API 66.0-67.0 property and setter additions, including enhanced payment data and retry metadata.
- Added the new `EnhancedPaymentDataInput` and `LineItemInput` classes used by the Summer '26 CommercePayments surface.

## Testing
- `mvn test -q` passed.