### PR TITLE
Add EventBus publishWithAccessLevel overloads for API 67.0

### DIFF
--- a/src/main/java/com/nawforce/runforce/System/EventBus.java
+++ b/src/main/java/com/nawforce/runforce/System/EventBus.java
@@ -23,4 +23,8 @@ public class EventBus {
   public static SaveResult publish(SObject sobject) {throw new java.lang.UnsupportedOperationException();}
   public static List<SaveResult> publish(List<SObject> sobjects, Object cb) {throw new java.lang.UnsupportedOperationException();}
   public static SaveResult publish(SObject sobject, Object cb) {throw new java.lang.UnsupportedOperationException();}
+  public static List<SaveResult> publishWithAccessLevel(List<SObject> sobjects, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
+  public static SaveResult publishWithAccessLevel(SObject sobject, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
+  public static List<SaveResult> publishWithAccessLevel(List<SObject> sobjects, Object cb, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
+  public static SaveResult publishWithAccessLevel(SObject sobject, Object cb, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
 }


### PR DESCRIPTION
## Summary
- Add the API 67.0 `EventBus.publishWithAccessLevel(...)` overloads for single and list platform events
- Include the callback variants alongside the existing `publish(...)` signatures

## Testing
- `mvn test` passed
- API 67.0 compile probes against the `pre-release` org compiled for the new overload shapes