### PR TITLE
Refine Search suggest signatures for API 67

### DIFF
--- a/src/main/java/com/nawforce/runforce/System/Search.java
+++ b/src/main/java/com/nawforce/runforce/System/Search.java
@@ -15,6 +15,7 @@
 package com.nawforce.runforce.System;
 
 import com.nawforce.runforce.Search.SearchResults;
+import com.nawforce.runforce.Search.SuggestionOption;
 import com.nawforce.runforce.Search.SuggestionResults;
 
 @SuppressWarnings("unused")
@@ -23,6 +24,6 @@ public class Search {
 	public static SearchResults find(String searchQuery, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
 	public static List<List<SObject>> query(String searchQuery) {throw new java.lang.UnsupportedOperationException();}
 	public static List<List<SObject>> query(String searchQuery, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
-	public static SuggestionResults suggest(String searchQuery, String sObjectType, Object options) {throw new java.lang.UnsupportedOperationException();}
-	public static SuggestionResults suggest(String searchQuery, String sObjectType, Object options, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
+	public static SuggestionResults suggest(String searchQuery, String sObjectType, SuggestionOption options) {throw new java.lang.UnsupportedOperationException();}
+	public static SuggestionResults suggest(String searchQuery, String sObjectType, SuggestionOption options, AccessLevel accessLevel) {throw new java.lang.UnsupportedOperationException();}
 }


### PR DESCRIPTION
## Summary
- Updated `System.Search.suggest` to accept `Search.SuggestionOption` instead of `Object`.
- Kept the API 67 `AccessLevel` overloads for `find`, `query`, and `suggest`.

## Testing
- Not run (not requested)