### PR TITLE
Add DocumentAI Apex types for API 67

### DIFF
--- a/src/main/java/com/nawforce/runforce/DocumentAI/Attribute.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/Attribute.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class Attribute {
+  public Double confidence;
+  public Map<String,Object> data;
+  public List<Error> errors;
+  public String name;
+  public List<MatchingRecord> matchingRecords;
+  public String type;
+  public String value;
+
+  public Attribute() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/BatchProcessor.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/BatchProcessor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Id;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class BatchProcessor {
+  public BatchProcessor() {throw new java.lang.UnsupportedOperationException();}
+
+  public Id execute() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateObjectConfiguration.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateObjectConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DuplicateObjectConfiguration {
+  public Boolean enabled;
+  public ObjectConfig objectConfig;
+  public List<ObjectConfig> objectConfigs;
+  public String objectName;
+
+  public DuplicateObjectConfiguration() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateRuleConfiguration.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateRuleConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DuplicateRuleConfiguration {
+  public Boolean allowSave;
+  public List<DuplicateObjectConfiguration> duplicateObjectConfigurations;
+  public Boolean enabled;
+  public Boolean includeRecordDetails;
+
+  public DuplicateRuleConfiguration() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/Error.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/Error.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class Error {
+  public String code;
+  public Map<String,Object> details;
+  public String message;
+  public String type;
+
+  public Error() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/ExtractionMetadata.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/ExtractionMetadata.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Datetime;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class ExtractionMetadata {
+  public Double confidence;
+  public String documentId;
+  public String documentType;
+  public List<Error> errors;
+  public Datetime extractedAt;
+  public Map<String,Object> metadata;
+  public String processorName;
+
+  public ExtractionMetadata() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/MatchingRecord.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/MatchingRecord.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Id;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class MatchingRecord {
+  public Map<String,Object> data;
+  public Map<String,Object> fieldValues;
+  public Double matchScore;
+  public String objectName;
+  public Id recordId;
+
+  public MatchingRecord() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/Node.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/Node.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class Node {
+  public List<Attribute> attributes;
+  public List<Node> children;
+  public Double confidence;
+  public Map<String,Object> data;
+  public List<Error> errors;
+  public String id;
+  public String label;
+  public List<MatchingRecord> matchingRecords;
+  public String type;
+  public String value;
+
+  public Node() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/ObjectConfig.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/ObjectConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class ObjectConfig {
+  public Boolean enabled;
+  public Map<String,String> fieldMappings;
+  public String objectName;
+
+  public ObjectConfig() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveInput.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveInput.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PostSaveInput {
+  public DuplicateRuleConfiguration duplicateRuleConfiguration;
+  public ExtractionMetadata extractionMetadata;
+  public Map<String,Object> input;
+  public List<Node> nodes;
+
+  public PostSaveInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveResult.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveResult.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PostSaveResult {
+  public List<Error> errors;
+  public ExtractionMetadata extractionMetadata;
+  public Map<String,Object> output;
+  public List<SavedRecordDetail> savedRecordDetails;
+  public Boolean success;
+
+  public PostSaveResult() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformInput.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformInput.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PostTransformInput {
+  public DuplicateRuleConfiguration duplicateRuleConfiguration;
+  public ExtractionMetadata extractionMetadata;
+  public Map<String,Object> input;
+  public List<Node> nodes;
+
+  public PostTransformInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformResult.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformResult.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PostTransformResult {
+  public List<Error> errors;
+  public ExtractionMetadata extractionMetadata;
+  public List<Node> nodes;
+  public Map<String,Object> output;
+  public Boolean success;
+
+  public PostTransformResult() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/DocumentAI/SavedRecordDetail.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/SavedRecordDetail.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.DocumentAI;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Id;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class SavedRecordDetail {
+  public Map<String,Object> data;
+  public List<Error> errors;
+  public String objectName;
+  public Id recordId;
+  public Boolean success;
+
+  public SavedRecordDetail() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}


### PR DESCRIPTION
## Summary
- Added the new `DocumentAI` namespace stubs for the API 67 surface.
- Included the release-note class set: `Error`, `ExtractionMetadata`, `DuplicateRuleConfiguration`, `DuplicateObjectConfiguration`, `ObjectConfig`, `PostTransformInput`, `PostTransformResult`, `Node`, `Attribute`, `MatchingRecord`, `PostSaveInput`, `PostSaveResult`, `SavedRecordDetail`, and `BatchProcessor`.
- Kept the change scoped to the new namespace package under `src/main/java/com/nawforce/runforce/DocumentAI`.

## Testing
- `mvn test` passed.
- Verified the connected pre-release org would not expose these types to anonymous Apex or dry-run deploy compile probes, so member-level validation remains limited by org visibility.