### PR TITLE
Add RecordUi picklist value support for API 66.0

### DIFF
--- a/src/main/java/com/nawforce/runforce/ConnectApi/AbstractPicklistValueAttributes.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/AbstractPicklistValueAttributes.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public abstract class AbstractPicklistValueAttributes {
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Double getBuildVersion() {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValue.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PicklistValue {
+  public AbstractPicklistValueAttributes attributes;
+  public String label;
+  public List<Integer> validFor;
+  public String value;
+
+  public PicklistValue() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Double getBuildVersion() {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValues.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValues.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PicklistValues {
+  public Map<String, Integer> controllerValues;
+  public PicklistValue defaultValue;
+  public String url;
+  public List<PicklistValue> values;
+
+  public PicklistValues() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Double getBuildVersion() {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValuesCollection.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValuesCollection.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class PicklistValuesCollection {
+  public Map<String, PicklistValues> picklistFieldValues;
+
+  public PicklistValuesCollection() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Double getBuildVersion() {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RecordUi.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RecordUi.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class RecordUi {
+  public static PicklistValuesCollection getPicklistValuesByRecordType(String objectApiName, String recordTypeId) {throw new java.lang.UnsupportedOperationException();}
+}


### PR DESCRIPTION
## Summary
- Add `ConnectApi.RecordUi.getPicklistValuesByRecordType(String, String)`.
- Introduce the dependent picklist models required by the API 66.0 surface:
  - `PicklistValuesCollection`
  - `PicklistValues`
  - `PicklistValue`
  - `AbstractPicklistValueAttributes`
- Model the Record UI response shape around `picklistFieldValues`, `controllerValues`, `defaultValue`, `values`, `label`, `value`, `validFor`, and `attributes`.

## Testing
- Verified the API signature and return type against the connected `pre-release` org with anonymous Apex compile probes.
- Confirmed the picklist field/value types and fields through compile/runtime probes.
- `mvn test` passed locally.