### PR TITLE
[codex] Add CdpQuery metadata entity types

### DIFF
--- a/src/main/java/com/nawforce/runforce/ConnectApi/CdpQuery.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CdpQuery.java
@@ -13,6 +13,9 @@ import com.nawforce.runforce.System.String;
 public class CdpQuery {
   public static CdpQueryMetadataOutput getAllMetadata() {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getAllMetadata(String entityType, String entityCategory, String entityName) {throw new java.lang.UnsupportedOperationException();}
+  public static MetadataEntityCollectionRepresentation getMetadataEntities() {throw new java.lang.UnsupportedOperationException();}
+  public static MetadataEntityCollectionRepresentation getMetadataEntities(String entityCategory, String entityType) {throw new java.lang.UnsupportedOperationException();}
+  public static MetadataEntityCollectionRepresentation getMetadataEntities(String entityCategory, String entityType, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getInsightsMetadata() {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getInsightsMetadata(String ciName) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getProfileMetadata() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityCollectionRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityCollectionRepresentation.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class MetadataEntityCollectionRepresentation {
+  public List<MetadataEntityRepresentation> metadata;
+
+  public MetadataEntityCollectionRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityRepresentation.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class MetadataEntityRepresentation {
+  public String category;
+  public String displayName;
+  public String name;
+  public String type;
+
+  public MetadataEntityRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}


### PR DESCRIPTION
## Summary
- add ConnectApi.CdpQuery.getMetadataEntities overloads for API 66.0
- add MetadataEntityCollectionRepresentation and MetadataEntityRepresentation using compile-probe-confirmed Apex-visible names and fields

## Validation
- mvn test

Addresses #61.