### PR TITLE
Fix API refresh copyright headers

### DIFF
--- a/src/main/java/com/nawforce/runforce/CommercePayments/EnhancedPaymentDataInput.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/EnhancedPaymentDataInput.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.CommercePayments;

--- a/src/main/java/com/nawforce/runforce/CommercePayments/LineItemInput.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/LineItemInput.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.CommercePayments;

--- a/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodIdType.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/PaymentMethodIdType.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.CommercePayments;

--- a/src/main/java/com/nawforce/runforce/CommercePayments/RetryCategory.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/RetryCategory.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.CommercePayments;

--- a/src/main/java/com/nawforce/runforce/CommercePayments/RetryDecision.java
+++ b/src/main/java/com/nawforce/runforce/CommercePayments/RetryDecision.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.CommercePayments;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/AbstractPicklistValueAttributes.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/AbstractPicklistValueAttributes.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityCollectionRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityCollectionRepresentation.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/MetadataEntityRepresentation.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValue.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValue.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValues.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValues.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValuesCollection.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/PicklistValuesCollection.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RecordUi.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RecordUi.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.ConnectApi;

--- a/src/main/java/com/nawforce/runforce/Database/CursorFetchResult.java
+++ b/src/main/java/com/nawforce/runforce/Database/CursorFetchResult.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.Database;

--- a/src/main/java/com/nawforce/runforce/Database/PaginationCursor.java
+++ b/src/main/java/com/nawforce/runforce/Database/PaginationCursor.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.Database;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/Attribute.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/Attribute.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/BatchProcessor.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/BatchProcessor.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateObjectConfiguration.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateObjectConfiguration.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateRuleConfiguration.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/DuplicateRuleConfiguration.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/Error.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/Error.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/ExtractionMetadata.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/ExtractionMetadata.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/MatchingRecord.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/MatchingRecord.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/Node.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/Node.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/ObjectConfig.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/ObjectConfig.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveInput.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveInput.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveResult.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostSaveResult.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformInput.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformInput.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformResult.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/PostTransformResult.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;

--- a/src/main/java/com/nawforce/runforce/DocumentAI/SavedRecordDetail.java
+++ b/src/main/java/com/nawforce/runforce/DocumentAI/SavedRecordDetail.java
@@ -1,5 +1,15 @@
 /*
- * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
  */
 
 package com.nawforce.runforce.DocumentAI;


### PR DESCRIPTION
## Summary
- replace short Certinia headers in recently-added API refresh files with the standard Kevin Jones BSD-style header
- normalize new-file copyright years to 2026

## Testing
- mvn test