### PR TITLE
Add ConnectApi commerce quote and cart API 67.0 stubs

### DIFF
--- a/src/main/java/com/nawforce/runforce/ConnectApi/BestLocationPerSKUOutputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/BestLocationPerSKUOutputRepresentation.java
@@ -1,0 +1,36 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class BestLocationPerSKUOutputRepresentation {
+  public List<ErrorResponse> errors;
+  public String locationId;
+  public Integer quantityAvailableToOrder;
+  public Boolean success;
+  public Double unitScore;
+
+  public BestLocationPerSKUOutputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CartFromQuoteInput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CartFromQuoteInput.java
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CartFromQuoteInput {
+  public String operationType;
+
+  public CartFromQuoteInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CartFromQuoteOutput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CartFromQuoteOutput.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CartFromQuoteOutput {
+  public String cartId;
+  public List<QuoteError> errors;
+
+  public CartFromQuoteOutput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CommerceCart.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CommerceCart.java
@@ -22,6 +22,7 @@ public class CommerceCart {
   public static CalculateCartResult calculateCart(String webstoreId, String activeCartOrId, String effectiveAccountId) {throw new UnsupportedOperationException();}
   public static CalculateCartResult calculateCart(String webstoreId, String activeCartOrId, String effectiveAccountId, ConnectApiCalculateCartInput calculateCartInput) {throw new java.lang.UnsupportedOperationException();}
   public static CartSummary createCart(String webstoreId, CartInput cart) {throw new java.lang.UnsupportedOperationException();}
+  public static CartFromQuoteOutput createCartFromQuote(String webstoreId, String quoteId, CartFromQuoteInput cartFromQuoteInput) {throw new java.lang.UnsupportedOperationException();}
   public static CartSummary cloneCart(String webstoreId, String activeCartOrId, String targetEffectiveAccountId, String targetType) {throw new java.lang.UnsupportedOperationException();}
   public static void deleteCart(String webstoreId, String effectiveAccountId, String activeCartOrId) {throw new java.lang.UnsupportedOperationException();}
   public static void deleteCartCoupon(String webstoreId, String effectiveAccountId, String activeCartOrId, String cartCouponId) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CommerceNoteInput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CommerceNoteInput.java
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CommerceNoteInput {
+  public String content;
+
+  public CommerceNoteInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CommerceQuotes.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CommerceQuotes.java
@@ -1,0 +1,23 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CommerceQuotes {
+  public static CreateQuoteFromProductOutput createQuoteFromProduct(String webstoreId, String productId, CreateQuoteFromProductInput createQuoteFromProductInput) {throw new java.lang.UnsupportedOperationException();}
+  public static UpdateQuoteOutput updateQuote(String webstoreId, String quoteId, UpdateQuoteInput updateQuoteInput) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CreateQuoteFromProductInput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CreateQuoteFromProductInput.java
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CreateQuoteFromProductInput {
+  public Map<String, String> additionalFields;
+  public String comments;
+  public String contextDefinitionName;
+  public String quantity;
+
+  public CreateQuoteFromProductInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CreateQuoteFromProductOutput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CreateQuoteFromProductOutput.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CreateQuoteFromProductOutput {
+  public List<QuoteError> errors;
+  public String quoteId;
+
+  public CreateQuoteFromProductOutput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DeliveryRoutingEngineInputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DeliveryRoutingEngineInputRepresentation.java
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DeliveryRoutingEngineInputRepresentation {
+  public DeliveryAddressInputRepresentation deliveryAddress;
+  public LocationListInputRepresentation excludeLocations;
+  public String fulfillmentCriteriaGroupName;
+  public String locationGroupName;
+  public List<RoutingProductInputRepresentation> products;
+
+  public DeliveryRoutingEngineInputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DeliveryRoutingEngineOutputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DeliveryRoutingEngineOutputRepresentation.java
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.Map;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DeliveryRoutingEngineOutputRepresentation {
+  public Map<String, List<BestLocationPerSKUOutputRepresentation>> bestLocationsPerStockKeepingUnit;
+  public List<ErrorResponse> errors;
+  public List<RouteOutputRepresentation> routes;
+  public Boolean success;
+
+  public DeliveryRoutingEngineOutputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/LocationListInputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/LocationListInputRepresentation.java
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class LocationListInputRepresentation {
+  public List<String> locations;
+
+  public LocationListInputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/QuoteError.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/QuoteError.java
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class QuoteError {
+  public String code;
+  public String message;
+
+  public QuoteError() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RouteLocationOutputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RouteLocationOutputRepresentation.java
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class RouteLocationOutputRepresentation {
+  public List<ErrorResponse> errors;
+  public String location;
+  public List<RouteProductOutputRepresentation> products;
+  public Boolean success;
+
+  public RouteLocationOutputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RouteOutputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RouteOutputRepresentation.java
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class RouteOutputRepresentation {
+  public List<ErrorResponse> errors;
+  public List<RouteLocationOutputRepresentation> locations;
+  public Boolean success;
+  public Double totalScore;
+
+  public RouteOutputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RouteProductOutputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RouteProductOutputRepresentation.java
@@ -1,0 +1,36 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class RouteProductOutputRepresentation {
+  public List<ErrorResponse> errors;
+  public String product;
+  public Integer quantity;
+  public Boolean success;
+  public Double unitScore;
+
+  public RouteProductOutputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RoutingProductInputRepresentation.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RoutingProductInputRepresentation.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Double;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class RoutingProductInputRepresentation {
+  public Double quantity;
+  public String stockKeepingUnit;
+
+  public RoutingProductInputRepresentation() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/UpdateQuoteInput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/UpdateQuoteInput.java
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class UpdateQuoteInput {
+  public CommerceNoteInput note;
+  public String status;
+
+  public UpdateQuoteInput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/UpdateQuoteOutput.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/UpdateQuoteOutput.java
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class UpdateQuoteOutput {
+  public List<ErrorResponse> errors;
+
+  public UpdateQuoteOutput() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}


### PR DESCRIPTION
## Summary
- Added the API 67.0 `CommerceCart.createCartFromQuote` entry point.
- Added missing quote commerce classes for `CommerceQuotes`, quote inputs/outputs, and note/error representations.
- Added the API 67 routing representations for best-location and delivery routing data.

## Testing
- `mvn test` passed locally.
- Verified the new signatures against the Salesforce Apex Reference Guide and a guarded `pre-release` Apex probe for the representation shapes.