### PR TITLE
Backfill CdpQuery dataspace and Data Graph APIs

### DIFF
--- a/src/main/java/com/nawforce/runforce/ConnectApi/CdpDgMetadata.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CdpDgMetadata.java
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CdpDgMetadata {
+  public List<CdpQueryDataGraphMetadata> dataGraphMetadata;
+
+  public CdpDgMetadata() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CdpQuery.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CdpQuery.java
@@ -13,15 +13,29 @@ import com.nawforce.runforce.System.String;
 public class CdpQuery {
   public static CdpQueryMetadataOutput getAllMetadata() {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getAllMetadata(String entityType, String entityCategory, String entityName) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryMetadataOutput getAllMetadata(String entityType, String entityCategory, String entityName, String dataspace) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpDgMetadata getDataGraphMetadata() {throw new java.lang.UnsupportedOperationException();}
+  public static CdpDgMetadata getDataGraphMetadata(String dataGraphEntityName) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpDgMetadata getDataGraphMetadata(String dataGraphEntityName, String dataspace) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphData(String dataGraphEntityName, String id) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphData(String dataGraphEntityName, String id, String dataspace) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphData(String dataGraphEntityName, String id, Boolean live) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphData(String dataGraphEntityName, String id, String dataspace, Boolean live) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphDataWithLookupKeys(String dataGraphEntityName, String lookupKeys) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphDataWithLookupKeys(String dataGraphEntityName, String lookupKeys, String dataspace) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput getDataGraphDataWithLookupKeys(String dataGraphEntityName, String lookupKeys, String dataspace, Boolean noCache) {throw new java.lang.UnsupportedOperationException();}
   public static MetadataEntityCollectionRepresentation getMetadataEntities() {throw new java.lang.UnsupportedOperationException();}
   public static MetadataEntityCollectionRepresentation getMetadataEntities(String entityCategory, String entityType) {throw new java.lang.UnsupportedOperationException();}
   public static MetadataEntityCollectionRepresentation getMetadataEntities(String entityCategory, String entityType, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getInsightsMetadata() {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getInsightsMetadata(String ciName) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryMetadataOutput getInsightsMetadata(String ciName, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getProfileMetadata() {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryMetadataOutput getProfileMetadata(String dataModelName) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryMetadataOutput getProfileMetadata(String dataModelName, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryANSISql(CdpQueryInput input) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryANSISql(CdpQueryInput input, Integer batchSize, Integer offset, String orderby) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput queryANSISql(CdpQueryInput input, Integer batchSize, Integer offset, String orderby, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutputV2 queryAnsiSqlV2(CdpQueryInput input) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutputV2 queryAnsiSqlV2(CdpQueryInput input, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutputV2 nextBatchAnsiSqlV2(String nextBatchId) {throw new java.lang.UnsupportedOperationException();}
@@ -46,10 +60,13 @@ public class CdpQuery {
   public static QuerySqlStatus querySqlStatus(String queryId, String workloadName, String dataspace, Integer waitTimeMs) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryCalculatedInsights(String ciName, String dimensions, String measures, String orderby, String filters, Integer batchSize, Integer offset) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryCalculatedInsights(String ciName, String dimensions, String measures, String orderby, String filters, Integer batchSize, Integer offset, String timeGranularity) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput queryCalculatedInsights(String ciName, String dimensions, String measures, String orderby, String filters, Integer batchSize, Integer offset, String timeGranularity, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryProfileApi(String dataModelName, String filters, String fields, Integer batchSize, Integer offset, String orderby) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryProfileApi(String dataModelName, String id, String searchKey, String filters, String fields, Integer batchSize, Integer offset, String orderby) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryProfileApi(String dataModelName, String id, String childDataModelName, String searchKey, String filters, String fields, Integer batchSize, Integer offset, String orderby) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryProfileApi(String dataModelName, String id, String ciName, String searchKey, String dimensions, String measures, String filters, String fields, Integer batchSize, Integer offset, String orderby) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryOutput queryProfileApi(String dataModelName, String id, String ciName, String searchKey, String dimensions, String measures, String filters, String fields, Integer batchSize, Integer offset, String orderby, String timeGranularity) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryOutput queryProfileApi(String dataModelName, String id, String ciName, String searchKey, String dimensions, String measures, String filters, String fields, Integer batchSize, Integer offset, String orderby, String timeGranularity, String dataspace) {throw new java.lang.UnsupportedOperationException();}
   public static CdpQueryDataOutput universalIdLookupBySourceId(String entityName, String dataSourceId, String dataSourceObjectId, String sourceRecordId) {throw new java.lang.UnsupportedOperationException();}
+  public static CdpQueryDataOutput universalIdLookupBySourceId(String entityName, String dataSourceId, String dataSourceObjectId, String sourceRecordId, String dataspace) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/ConnectApi/CdpQueryDataGraphMetadata.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/CdpQueryDataGraphMetadata.java
@@ -1,0 +1,40 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class CdpQueryDataGraphMetadata {
+  public String dataspaceName;
+  public String description;
+  public String developerName;
+  public DataGraphObjectData dgObject;
+  public Object extendedProperties;
+  public String idDmoName;
+  public DataGraphIdsDmo idsDmo;
+  public String primaryObjectName;
+  public DataGraphObjectTypeEnum primaryObjectType;
+  public DataGraphStatusEnum status;
+  public DataGraphValuesDmo valuesDmo;
+
+  public CdpQueryDataGraphMetadata() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DaoObjectFieldTypeQueryEnum.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DaoObjectFieldTypeQueryEnum.java
@@ -1,0 +1,22 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+@SuppressWarnings("unused")
+public enum DaoObjectFieldTypeQueryEnum {
+  Dimension,
+  Measure,
+  ObjectTypeUnspecified
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphField.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphField.java
@@ -1,0 +1,39 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphField {
+  public DaoObjectFieldTypeQueryEnum ciFieldType;
+  public String dataGraphFieldDevName;
+  public String dataType;
+  public String developerName;
+  public String isProjected;
+  public String keyCol;
+  public String keyQualifierName;
+  public String length;
+  public String lookupCol;
+  public String usageTag;
+
+  public DataGraphField() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphIdsDmo.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphIdsDmo.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphIdsDmo {
+  public String developerName;
+  public List<DataGraphIdsDmoField> fields;
+
+  public DataGraphIdsDmo() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphIdsDmoField.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphIdsDmoField.java
@@ -1,0 +1,33 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphIdsDmoField {
+  public List<Integer> capabilities;
+  public String dataType;
+  public String developerName;
+
+  public DataGraphIdsDmoField() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphObjectData.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphObjectData.java
@@ -1,0 +1,39 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphObjectData {
+  public String dataGraphSourceDevName;
+  public String developerName;
+  public List<DataGraphField> fields;
+  public String filterCriteria;
+  public String memberDmoName;
+  public List<DataGraphRelationship> paths;
+  public List<RecencyCriteria> recencyCriteria;
+  public List<DataGraphObjectData> relatedObjects;
+  public DataGraphObjectTypeEnum type;
+
+  public DataGraphObjectData() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphObjectTypeEnum.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphObjectTypeEnum.java
@@ -1,0 +1,36 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+@SuppressWarnings("unused")
+public enum DataGraphObjectTypeEnum {
+  Adg,
+  AdgActivationAudience,
+  AdgExternal,
+  Bridge,
+  Calculated,
+  CalculatedRealTime,
+  CalculatedStreaming,
+  Curated,
+  Custom,
+  Derived,
+  MlPrediction,
+  ObjectTypeUnspecified,
+  Package,
+  SegmentMembership,
+  Standard,
+  System,
+  Transform
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphRelationship.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphRelationship.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphRelationship {
+  public RelationshipCardinality cardinality;
+  public String fieldName;
+  public String parentFieldName;
+
+  public DataGraphRelationship() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphStatusEnum.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphStatusEnum.java
@@ -1,0 +1,25 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+@SuppressWarnings("unused")
+public enum DataGraphStatusEnum {
+  Error,
+  Inprogress,
+  Published,
+  Ready,
+  StatusUnspecified,
+  Unrecognized
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphValuesDmo.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphValuesDmo.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphValuesDmo {
+  public String developerName;
+  public List<DataGraphValuesDmoField> fields;
+
+  public DataGraphValuesDmo() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphValuesDmoField.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/DataGraphValuesDmoField.java
@@ -1,0 +1,33 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.List;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class DataGraphValuesDmoField {
+  public List<Integer> capabilities;
+  public String dataType;
+  public String developerName;
+
+  public DataGraphValuesDmoField() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RecencyCriteria.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RecencyCriteria.java
@@ -1,0 +1,33 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+import com.nawforce.runforce.System.Boolean;
+import com.nawforce.runforce.System.Integer;
+import com.nawforce.runforce.System.String;
+
+@SuppressWarnings("unused")
+public class RecencyCriteria {
+  public String fieldName;
+  public String value;
+  public String valueType;
+  public String valueUnit;
+
+  public RecencyCriteria() {throw new java.lang.UnsupportedOperationException();}
+
+  public Boolean equals$(Object obj) {throw new java.lang.UnsupportedOperationException();}
+  public Integer hashCode$() {throw new java.lang.UnsupportedOperationException();}
+  public String toString$() {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/com/nawforce/runforce/ConnectApi/RelationshipCardinality.java
+++ b/src/main/java/com/nawforce/runforce/ConnectApi/RelationshipCardinality.java
@@ -1,0 +1,23 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.runforce.ConnectApi;
+
+@SuppressWarnings("unused")
+public enum RelationshipCardinality {
+  CardinalityUnspecified,
+  ManyToOne,
+  OneToMany,
+  OneToOne
+}


### PR DESCRIPTION
## Summary
- Add missing `CdpQuery` dataspace overloads for metadata, query, and lookup methods.
- Add Data Graph metadata/data stubs plus the direct dependent DTOs and enums they reference.
- Keep the change limited to the ConnectApi CdpQuery surface requested in #62.

## Testing
- `mvn test` passed locally, including a full Java compile of the updated stub set.