### PR TITLE
Refresh Maven tooling versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.15.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -78,11 +78,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.5.0</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.11.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -100,7 +101,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -114,7 +115,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.8</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -136,7 +137,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.10.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
@@ -147,7 +148,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>3.5.6</version>
         <configuration>
           <skip>false</skip>
         </configuration>
@@ -156,7 +157,7 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
-        <version>4.8-1</version>
+        <version>4.13.2</version>
         <executions>
           <execution>
             <id>antlr</id>
@@ -173,7 +174,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary
- refresh Maven build, publishing, ANTLR, Surefire, source, javadoc, jar, compiler, and GPG plugin versions
- add the previously implicit maven-dependency-plugin version
- leave generated/API artifacts and runtime dependency coordinates unchanged

## Testing
- `mvn test`
- `mvn install -Dgpg.skip=true`
- `(../apex-ls) sbt 'apexlsJVM / Test / testOnly com.nawforce.apexlink.types.PlatformTypesValidationTest -- -z "All outer types are valid"'`\n\nNote: the full apex-ls `PlatformTypesValidationTest` also confirmed dynamic loading passes, but its fixed count assertion is stale after the recent type refresh (`6174` expected, `6234` found).\n