### PR TITLE
Update GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 11

--- a/.github/workflows/PublishMaven.yml
+++ b/.github/workflows/PublishMaven.yml
@@ -9,10 +9,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: "temurin"


### PR DESCRIPTION
Bumps `actions/checkout` v4 → v6 and `actions/setup-java` v4 → v5 in both workflows to resolve the Node.js 20 deprecation warning. Node 20 actions will be forced onto Node 24 from June 16th 2026 and removed from runners on September 16th 2026. Both new majors are drop-in for our usage.