### PR TITLE
Update version to 67.0.0 for Summer '26

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Stub declarations for Salesforce platform types encoded as compilable Java.
 
 These stub declarations help support static analysis of Apex code in [apex-ls](https://github.com/apex-dev-tools/apex-ls) but you may also find them useful for other purposes. They have been encoded in Java to get the benefit of type checking by javac so it easier to spot when something is amiss. In apex-ls JVM reflection is used to 'read' the stubs as part of the static analysis.
 
-The library is versioned to reflect Salesforce API numbers, so currently v65.X.X matches the Salesforce Winter '26 API.
+The library is versioned to reflect Salesforce API numbers, so currently v67.X.X matches the Salesforce Summer '26 API.
 
 ## Coverage Scope
 
@@ -33,7 +33,7 @@ To use the jar in a maven project add the following to your pom.xml
 <dependency>
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>65.0.0</version>
+  <version>67.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>65.0.0</version>
+  <version>67.0.0</version>
   <packaging>jar</packaging>
 
   <name>standard-types</name>


### PR DESCRIPTION
Bumps the project version to 67.0.0, matching the Salesforce Summer '26 API, ahead of the v67.0.0 release. Updates the README versioning note and installation snippet to match. Verified locally with `mvn -B install -Dgpg.skip`.