### PR TITLE
Add Formula Exception Stubs to System Namespace

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+@../.github/copilot-instructions.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ This repository provides Java stub declarations for Salesforce platform types to
 
 - **Root package**: `io.github.apexdevtools.standardtypes`
 - **Namespace mapping**: Each Salesforce namespace becomes a Java package (e.g., `System` → `io.github.apexdevtools.standardtypes.System`)
-- **Cross-references**: Types reference each other using proper `io.github.apexdevtools.standardtypes.*` imports, never native Java types (except `Object`)
+- **Cross-references**: Types reference each other using proper `io.github.apexdevtools.standardtypes.*` imports, never native Java types. Permitted native Java types are limited to `Object`, `Exception` (exception stubs extend it and take it as a parameter), and `java.lang.UnsupportedOperationException` (thrown by every method body)
 
 ### Key Package Categories
 
@@ -25,15 +25,33 @@ This repository provides Java stub declarations for Salesforce platform types to
 
 ### Stub Implementation Pattern
 
-Every method follows this exact pattern:
+Every file starts with the standard BSD-style copyright header (see below), followed by the package, an optional documentation-link comment, and the class. Every method throws `UnsupportedOperationException`:
 
 ```java
+/*
+ Copyright (c) <current year> Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.standardtypes.<Namespace>;
+
 // [link to class documentation page]
 @SuppressWarnings("unused")
 public class ExampleClass {
   public ReturnType methodName(ParamType param) {throw new java.lang.UnsupportedOperationException();}
 }
 ```
+
+Copy the header verbatim from an existing file in the same namespace (e.g. `System/MathException.java`), updating only the year.
 
 ### Type Import Rules ⚠️
 
@@ -86,7 +104,7 @@ public class InstanceClass {
 - **⚠️ CRITICAL: Getters/setters**: NEVER auto-generate getter/setter methods. ONLY create methods that are explicitly documented in the Salesforce API documentation. Properties are public fields unless documentation shows otherwise.
 - **⚠️ CRITICAL: Methods only**: Create ONLY the methods that appear in the official Salesforce documentation. Do not add any convenience methods, utility methods, or standard Java patterns not documented.
 - **Constructor patterns**: Static method classes have no constructors; instance classes have public default constructor plus any documented constructors
-- **Copyright year**: Use current year (2025) for newly created files
+- **Copyright year**: Use the current calendar year in the header of newly created files
 
 ## Build & Development
 
@@ -98,7 +116,7 @@ mvn install -Dgpg.skip=true  # Skip GPG signing for local builds
 
 ### Version Strategy
 
-- Versions track Salesforce API releases (e.g., v64.X.X = Summer '25 API)
+- Versions track Salesforce API releases (e.g., v67.X.X = Summer '26 API)
 - Built for Java 1.8 compatibility for wider tooling support
 
 ### File Organization
@@ -140,7 +158,7 @@ Create `.github/[namespace-name]-todo.md` with a simple structure:
 ### Adding New Salesforce Types
 
 1. **Determine package location** based on Salesforce namespace mapping
-2. **Set copyright year** to current year (2025) for new files
+2. **Add the copyright header** (copy from an existing file in the namespace) and set the year to the current calendar year
 3. **Preserve documentation order** - maintain alphabetical method/property order from API docs
 4. **Choose class pattern**:
    - Static method classes: No constructors

--- a/src/main/java/io/github/apexdevtools/standardtypes/System/FormulaEvaluationException.java
+++ b/src/main/java/io/github/apexdevtools/standardtypes/System/FormulaEvaluationException.java
@@ -1,0 +1,23 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.standardtypes.System;
+
+@SuppressWarnings("unused")
+public class FormulaEvaluationException extends Exception {
+	public FormulaEvaluationException() {throw new java.lang.UnsupportedOperationException();}
+	public FormulaEvaluationException(Exception param1) {throw new java.lang.UnsupportedOperationException();}
+	public FormulaEvaluationException(String param1) {throw new java.lang.UnsupportedOperationException();}
+	public FormulaEvaluationException(String param1, Exception param2) {throw new java.lang.UnsupportedOperationException();}
+}

--- a/src/main/java/io/github/apexdevtools/standardtypes/System/FormulaValidationException.java
+++ b/src/main/java/io/github/apexdevtools/standardtypes/System/FormulaValidationException.java
@@ -1,0 +1,23 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.standardtypes.System;
+
+@SuppressWarnings("unused")
+public class FormulaValidationException extends Exception {
+	public FormulaValidationException() {throw new java.lang.UnsupportedOperationException();}
+	public FormulaValidationException(Exception param1) {throw new java.lang.UnsupportedOperationException();}
+	public FormulaValidationException(String param1) {throw new java.lang.UnsupportedOperationException();}
+	public FormulaValidationException(String param1, Exception param2) {throw new java.lang.UnsupportedOperationException();}
+}


### PR DESCRIPTION
# Summary

This PR adds `FormulaEvaluationException` and `FormulaValidationException` to the `System` package so apex-ls resolves the exceptions the `FormulaEval` API throws, instead of reporting "No type declaration found". Closes #77.

Both follow the standard exception-stub pattern (extends `Exception`, four universal constructors, bodies throwing `UnsupportedOperationException`), matching `MathException`.

### Salesforce Documentation

These exceptions are real but oddly undocumented, they appear only in prose and only in the original preview note:

- [EA note (248 / Spring '24)](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_formulaeval.htm&release=248&type=5): `build()` triggers `FormulaValidationException`, `evaluate()` triggers `FormulaEvaluationException`
- [GA note (254)](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_formulaeval.htm&release=254&type=5): announces GA, drops all mention of them
- [FormulaEval namespace ref](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_namespace_formulaeval.htm): lists the other classes, not these exceptions
- [IdeaExchange origin](https://ideas.salesforce.com/s/idea/a0B8W00000Gdi25UAB/evaluate-dynamic-formula-with-apex)

> **NOTE:** No `// [doc link]` comment on either class since no reference page exists to point at.

### Testing/Evidence

Run the following Apex snippet against an org on API version 67.0:

```
// Reference the types explicitly so the compiler must resolve them under System.
System.Type validationType = System.FormulaValidationException.class;
System.Type evaluationType = System.FormulaEvaluationException.class;
System.debug('Resolved type (validation): ' + validationType.getName());
System.debug('Resolved type (evaluation): ' + evaluationType.getName());

// FormulaValidationException — thrown at build() time by an invalid formula.
try {
    Formula.builder()
        .withType(Account.SObjectType)
        .withReturnType(FormulaEval.FormulaReturnType.Decimal)
        .withFormula('NOT_A_FUNCTION(1)')
        .build()
        .evaluate(new Account());
} catch (System.FormulaValidationException fe) {
    System.debug('Caught System.FormulaValidationException: ' + fe.getMessage());
}

// FormulaEvaluationException — thrown at evaluate() time (division by zero).
try {
    Formula.builder()
        .withType(Account.SObjectType)
        .withReturnType(FormulaEval.FormulaReturnType.Decimal)
        .withFormula('1 / 0')
        .build()
        .evaluate(new Account());
} catch (System.FormulaEvaluationException fee) {
    System.debug('Caught System.FormulaEvaluationException: ' + fee.getMessage());
}
```

<img width="957" height="94" alt="Screenshot 2026-07-23 at 17 10 59" src="https://github.com/user-attachments/assets/0128a151-fd73-4a2e-8160-ecb825f9bde3" />


### Additional Changes

- `.github/copilot-instructions.md` tweaks: "current calendar year" instead of hardcoded 2025, v64/Summer '25 bumped to v67/Summer '26, native-type allowlist spelled out, full header example
- Ensure that Claude picks up the project instructions by adding a new `.claude/CLAUDE.md` which just references `.github/copilot-instructions.md`