### PR TITLE
Build and publish with JDK 17

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: 17
           cache: "maven"
 
       - name: Build with Maven

--- a/.github/workflows/PublishMaven.yml
+++ b/.github/workflows/PublishMaven.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
           cache: "maven"
           server-id: central

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>8</release>
           <compilerArgument>-parameters</compilerArgument>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Summary
- build and publish with Temurin JDK 17 in CI
- replace legacy `source/target 1.8` with `<release>8</release>` so Java 8 APIs and bytecode are enforced

## Verification
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home mvn -B install -Dgpg.skip`
- build passed; no tests are present
- 1,703 sources compiled with `release 8`
- verified a compiled class with `javap -v`: major version 52 (Java 8)
