### PR TITLE
Prepare for 67.0.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>67.0.0</version>
+  <version>67.0.1</version>
   <packaging>jar</packaging>
 
   <name>standard-types</name>


### PR DESCRIPTION
# Summary

This PR bumps the pom to 67.0.1 so the changes in https://github.com/apex-dev-tools/standard-types/issues/77 are ready to be released.

## Release plan

1. Merge this PR, then confirm `Build.yml` is green on the merge commit.
2. Publish a release targeting `main` with tag `v67.0.1`.
3. Verify at [https://repo1.maven.org/maven2/io/github/apex-dev-tools/standard-types/](https://repo1.maven.org/maven2/io/github/apex-dev-tools/standard-types/)

Following this, https://github.com/apex-dev-tools/apex-ls will be updated to consume the new `standard-types` version.