### PR TITLE
docs: update README version to 67.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use the jar in a maven project add the following to your pom.xml
 <dependency>
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>standard-types</artifactId>
-  <version>67.0.0</version>
+  <version>67.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

Update only the Maven dependency example in `README.md` from 67.0.0 to 67.0.1 so users copying the snippet after the release receive the current artifact version.

This complements #80 rather than duplicating it. #80 carries the project version bump in `pom.xml`; this PR contains no `pom.xml`, source, build, or publishing changes.

Because this change is documentation-only and does not affect the artifact that gets published, it can merge before or after #80 and before or after the 67.0.1 release is cut.

## Validation

- Confirmed the branch differs from `main` only in the README dependency snippet.
- `git diff --check` passes.